### PR TITLE
refactor: migrate font from Source Sans Pro to Source Sans 3

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { cssBundleHref } from '@remix-run/css-bundle';
 import {
   json,
   type LinksFunction,
@@ -14,8 +15,8 @@ import {
   useLocation,
   useMatches,
 } from '@remix-run/react';
-import sourceSansPro300 from '@fontsource/source-sans-pro/latin-300.css';
-import sourceSansPro400 from '@fontsource/source-sans-pro/latin-400.css';
+import sourceSans3Latin300 from '@fontsource/source-sans-3/latin-300.css';
+import sourceSans3Latin400 from '@fontsource/source-sans-3/latin-400.css';
 // @ts-ignore
 import faviconIcoUrl from '../public/favicon.ico';
 import icon32Url from '~/images/icon-32x32.png';
@@ -68,6 +69,7 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data }) => {
 };
 
 export const links: LinksFunction = () => [
+  ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
   {
     rel: 'preconnect',
     href: 'https://images.ctfassets.net/',
@@ -78,8 +80,8 @@ export const links: LinksFunction = () => [
   { rel: 'icon', type: 'image/png', sizes: '32x32', href: icon32Url },
   { rel: 'apple-touch-icon', sizes: '180x180', href: appleTouchIconUrl },
   { rel: 'manifest', href: '/manifest.webmanifest' },
-  { rel: 'stylesheet', href: sourceSansPro300 },
-  { rel: 'stylesheet', href: sourceSansPro400 },
+  { rel: 'stylesheet', href: sourceSans3Latin300 },
+  { rel: 'stylesheet', href: sourceSans3Latin400 },
   { rel: 'stylesheet', href: appStylesUrl },
 ];
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -4,23 +4,23 @@
 
 /* Customized fallback fonts to avoid CLS, values courtsey of fontpie */
 @font-face {
-  font-family: 'Source Sans Pro Fallback';
+  font-family: 'Source Sans 3 Fallback';
   font-style: normal;
   font-weight: theme('fontWeight.light');
   src: local('Arial');
-  ascent-override: 108.45%;
-  descent-override: 30.09%;
+  ascent-override: 112.86%;
+  descent-override: 44.08%;
   line-gap-override: 0%;
   size-adjust: 90.73%;
 }
 
 @font-face {
-  font-family: 'Source Sans Pro Fallback';
+  font-family: 'Source Sans 3 Fallback';
   font-style: normal;
   font-weight: theme('fontWeight.normal');
   src: local('Arial');
-  ascent-override: 104.47%;
-  descent-override: 28.98%;
+  ascent-override: 108.71%;
+  descent-override: 42.47%;
   line-gap-override: 0%;
   size-adjust: 94.19%;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "@fontsource/source-sans-pro": "5.0.3",
+        "@fontsource/source-sans-3": "5.0.3",
         "@prisma/client": "4.16.2",
+        "@remix-run/css-bundle": "1.18.1",
         "@remix-run/express": "1.18.1",
         "@remix-run/node": "1.18.1",
         "@remix-run/react": "1.18.1",
@@ -2626,10 +2627,10 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@fontsource/source-sans-pro": {
+    "node_modules/@fontsource/source-sans-3": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-5.0.3.tgz",
-      "integrity": "sha512-mQnjuif/37VxwRloHZ+wQdoozd2VPWutbFSt1AuSkk7nFXIBQxHJLw80rgCF/osL0t7N/3Gx1V7UJuOX2zxzhQ=="
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-3/-/source-sans-3-5.0.3.tgz",
+      "integrity": "sha512-5oQh3zLBiWpv2v50X2cq1iqJ2LG9M6XjGdWZJHs8LYfUFj+YenK5LzSE7sx9p4NFMtZFSNQAsc8CKdHHxzMXjA=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -3061,6 +3062,14 @@
       "version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
       "integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg=="
+    },
+    "node_modules/@remix-run/css-bundle": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/css-bundle/-/css-bundle-1.18.1.tgz",
+      "integrity": "sha512-j6CflpY3fmMb1chZLBvNPifLmAVWexXJ+tiiZKwXC/eVIrbKADlQCsWmTdYPjsMP+OkZja7TGdSivqQOjCAu0Q==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@remix-run/dev": {
       "version": "1.18.1",
@@ -23233,10 +23242,10 @@
       "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
       "dev": true
     },
-    "@fontsource/source-sans-pro": {
+    "@fontsource/source-sans-3": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-5.0.3.tgz",
-      "integrity": "sha512-mQnjuif/37VxwRloHZ+wQdoozd2VPWutbFSt1AuSkk7nFXIBQxHJLw80rgCF/osL0t7N/3Gx1V7UJuOX2zxzhQ=="
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-3/-/source-sans-3-5.0.3.tgz",
+      "integrity": "sha512-5oQh3zLBiWpv2v50X2cq1iqJ2LG9M6XjGdWZJHs8LYfUFj+YenK5LzSE7sx9p4NFMtZFSNQAsc8CKdHHxzMXjA=="
     },
     "@gar/promisify": {
       "version": "1.1.3",
@@ -23566,6 +23575,11 @@
       "version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
       "integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg=="
+    },
+    "@remix-run/css-bundle": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/css-bundle/-/css-bundle-1.18.1.tgz",
+      "integrity": "sha512-j6CflpY3fmMb1chZLBvNPifLmAVWexXJ+tiiZKwXC/eVIrbKADlQCsWmTdYPjsMP+OkZja7TGdSivqQOjCAu0Q=="
     },
     "@remix-run/dev": {
       "version": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
     "start": "cross-env NODE_ENV=production node ./build/server/index.js"
   },
   "dependencies": {
-    "@fontsource/source-sans-pro": "5.0.3",
+    "@fontsource/source-sans-3": "5.0.3",
     "@prisma/client": "4.16.2",
+    "@remix-run/css-bundle": "1.18.1",
     "@remix-run/express": "1.18.1",
     "@remix-run/node": "1.18.1",
     "@remix-run/react": "1.18.1",

--- a/remix.config.js
+++ b/remix.config.js
@@ -4,7 +4,12 @@
 module.exports = {
   ignoredRouteFiles: ['**/.*'],
   postcss: true,
-  serverDependenciesToBundle: ['marked', 'p-throttle'],
+  serverDependenciesToBundle: [
+    // Styling docs indicate this is needed, but I don't notice any difference?
+    '@fontsource/source-sans-3',
+    'marked',
+    'p-throttle',
+  ],
   serverModuleFormat: 'cjs',
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,8 @@ module.exports = {
         cream: '#eedebf', // closest: orange-200
       },
       fontFamily: {
-        sans: ['Source Sans Pro', 'Source Sans Pro Fallback'],
+        // Note: must be double-quoted strings if there's a number in the name
+        sans: ['"Source Sans 3"', '"Source Sans 3 Fallback"'],
       },
       transitionTimingFunction: {
         default: 'ease',


### PR DESCRIPTION
Source Sans Pro seems to have been replaced with Source Sans 3 in the Google Fonts directory. I can only assume SSP is deprecated or something.