### PR TITLE
build: remove assetsInlineLimit from Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,11 +7,6 @@ import tsConfigPaths from 'vite-tsconfig-paths';
 import { iconsSpritesheet } from 'vite-plugin-icons-spritesheet';
 
 export default defineConfig({
-  build: {
-    // Our SVG icons sprite is smaller than the default limit of 4096, so it
-    // gets inlined as a data URL, which is not what we want.
-    assetsInlineLimit: 2048,
-  },
   optimizeDeps: {
     include: ['algoliasearch', 'clsx', 'lodash-es'],
   },


### PR DESCRIPTION
No longer needed thanks to vite-plugin-icons-spritesheet v2.2.0.