### PR TITLE
fix: eliminate self-request in healthcheck endpoint

### DIFF
--- a/app/routes/[_].healthcheck.ts
+++ b/app/routes/[_].healthcheck.ts
@@ -1,19 +1,3 @@
-import { invariant } from '@epic-web/invariant';
-import type { Route } from './+types/[_].healthcheck';
-
-export async function loader({ request }: Route.LoaderArgs) {
-  const host = request.headers.get('X-Forwarded-Host') || request.headers.get('host');
-  const url = new URL('/', `http://${host}`);
-
-  try {
-    const response = await fetch(url.toString(), {
-      method: 'HEAD',
-      headers: { 'x-from-healthcheck': 'true' },
-    });
-    invariant(response.ok, `HEAD request failed to ${url}`);
-    return new Response('OK', { status: 200 });
-  } catch (error) {
-    console.log('❌ Healthcheck failed', { error });
-    return new Response('ERROR', { status: 500 });
-  }
+export async function loader() {
+  return new Response('OK', { status: 200 });
 }


### PR DESCRIPTION
I think this HEAD request that Fly hits every ~5 seconds was causing the index loader to run, querying Contentful for all drink data and likely even requesting all the images. 🤦‍♂️