### PR TITLE
fix(deploy): run app as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ COPY --from=build /myapp/build /myapp/build
 COPY --from=build /myapp/public /myapp/public
 COPY --from=build /myapp/package.json /myapp/package.json
 
+# run the app as the node (non-root) user
+RUN chown -R node:node /myapp
+USER node
+
 # accept some build arguments
 ARG COMMIT_SHA="unknown"
 ARG DEPLOYMENT_ENV="unknown"


### PR DESCRIPTION
This pull request introduces a security and best practice improvement to the Docker build process by ensuring the application runs as a non-root user. The main change is the addition of steps to set file ownership and switch to the `node` user in the `Dockerfile`.

Security and deployment improvements:

* Updated the `Dockerfile` to change ownership of the `/myapp` directory to the `node` user and set the container to run as `node` instead of root, reducing security risks and following Docker best practices.