### PR TITLE
chore(deps): remove glob from devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "del-cli": "7.0.0",
         "esbuild": "0.27.0",
         "eslint": "9.39.1",
-        "glob": "11.0.3",
         "node-html-parser": "7.0.1",
         "npm-run-all2": "8.0.4",
         "prettier": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "del-cli": "7.0.0",
     "esbuild": "0.27.0",
     "eslint": "9.39.1",
-    "glob": "11.0.3",
     "node-html-parser": "7.0.1",
     "npm-run-all2": "8.0.4",
     "prettier": "3.6.2",


### PR DESCRIPTION
I have no idea why this was here to begin with. Must've been used in the past?
