### PR TITLE
Update pnpm usage in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:24-bullseye-slim AS base
 ENV NODE_ENV="production"
 
 # install pnpm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10.25.0
 
 # set the working directory
 WORKDIR /myapp
@@ -14,13 +14,13 @@ WORKDIR /myapp
 FROM base AS dev-deps
 
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 # Install production-only node_modules
 FROM base AS prod-deps
 
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --prod --no-optional
+RUN pnpm install --prod --no-optional --frozen-lockfile 
 
 # Build the app
 FROM base AS build


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve the reliability and reproducibility of Node.js application builds by specifying an exact version of `pnpm` and ensuring lockfile consistency during dependency installation.

Dependency management improvements:

* The global `pnpm` installation now pins the version to `10.25.0` instead of using the latest, ensuring consistent builds across environments.
* Both development and production dependency installation steps now use the `--frozen-lockfile` flag with `pnpm install` to guarantee that the installed dependencies strictly match those specified in `pnpm-lock.yaml`, preventing accidental lockfile modifications during builds.