### PR TITLE
chore: remove dead exports and unused function

### DIFF
--- a/app/admin/use-sortable-data.ts
+++ b/app/admin/use-sortable-data.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-export type SortState<T> = {
+type SortState<T> = {
   key: keyof T & string;
   direction: 'asc' | 'desc';
 };

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -9,7 +9,7 @@ export async function getUserById(id: User['id']): Promise<User | undefined> {
   });
 }
 
-export async function getUserByEmail(email: User['email']): Promise<User | undefined> {
+async function getUserByEmail(email: User['email']): Promise<User | undefined> {
   const db = getDb();
   return db.query.users.findFirst({
     where: eq(users.email, email),

--- a/app/search/cache.server.ts
+++ b/app/search/cache.server.ts
@@ -3,7 +3,7 @@ import { getAllDrinks } from '#/app/models/drink.server';
 import type { Drink } from '#/app/db/schema';
 import { createSearchIndex } from '#/app/search/minisearch.server';
 
-export const SEARCH_INSTANCE_CACHE_KEY = 'minisearch-index';
+const SEARCH_INSTANCE_CACHE_KEY = 'minisearch-index';
 
 type SearchData = {
   allDrinks: Drink[];

--- a/app/tags/utils.ts
+++ b/app/tags/utils.ts
@@ -1,7 +1,3 @@
 export function getSurrogateKeyForTag(tag: string) {
   return tag.replaceAll(' ', '_');
 }
-
-export function getTagFromSurrogateKey(surrogateKey: string) {
-  return surrogateKey.replaceAll('_', ' ');
-}

--- a/app/utils/fastly.server.ts
+++ b/app/utils/fastly.server.ts
@@ -3,7 +3,7 @@ import { getSurrogateKeyForTag } from '#/app/tags/utils';
 
 const { FASTLY_SERVICE_ID, FASTLY_PURGE_API_KEY } = getEnvVars();
 
-export async function purgeFastlyCache(surrogateKeys: string[]): Promise<void> {
+async function purgeFastlyCache(surrogateKeys: string[]): Promise<void> {
   if (!FASTLY_SERVICE_ID || !FASTLY_PURGE_API_KEY) {
     console.log('Fastly not configured, skipping cache purge');
     return;

--- a/app/utils/parse-image-upload.server.ts
+++ b/app/utils/parse-image-upload.server.ts
@@ -3,7 +3,7 @@ import { FormDataParseError, parseFormData, type FileUpload } from '@remix-run/f
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 
-export type ImageUpload = {
+type ImageUpload = {
   buffer: Buffer;
   contentType: string;
 };


### PR DESCRIPTION
## Summary
- Delete unused `getTagFromSurrogateKey` function (inverse of `getSurrogateKeyForTag`, never called)
- Un-export module-internal symbols that don't need to be public: `getUserByEmail`, `purgeFastlyCache`, `SEARCH_INSTANCE_CACHE_KEY`, `ImageUpload`, `SortState`

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- CI should confirm no consumers of these exports exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)