### PR TITLE
chore: remove dead exports and unused functions

### DIFF
--- a/app/db/client.server.ts
+++ b/app/db/client.server.ts
@@ -7,24 +7,12 @@ const { DATABASE_URL } = getEnvVars();
 
 let sqlite: Database.Database | null = null;
 
-export function getDatabase() {
+function getDatabase() {
   if (!sqlite) {
     sqlite = new Database(DATABASE_URL);
     sqlite.pragma('journal_mode = WAL');
   }
   return sqlite;
-}
-
-export function closeDatabase() {
-  if (sqlite) {
-    sqlite.close();
-    sqlite = null;
-  }
-}
-
-export function resetDatabaseConnection() {
-  closeDatabase();
-  return getDatabase();
 }
 
 export function getDb() {

--- a/app/utils/imagekit.server.ts
+++ b/app/utils/imagekit.server.ts
@@ -14,7 +14,7 @@ function getImageKit() {
   });
 }
 
-export async function uploadImage(file: Buffer, fileName: string): Promise<UploadResult> {
+async function uploadImage(file: Buffer, fileName: string): Promise<UploadResult> {
   const imagekit = getImageKit();
 
   const response = await imagekit.files.upload({


### PR DESCRIPTION
## Summary
- Un-export `getDatabase` in `client.server.ts` (only used internally by `getDb`)
- Remove `closeDatabase` and `resetDatabaseConnection` from `client.server.ts` (completely unused)
- Un-export `uploadImage` in `imagekit.server.ts` (only called internally by `uploadImageOrPlaceholder`)

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)