### PR TITLE
feat(admin): show createdAt/updatedAt

### DIFF
--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -39,6 +39,7 @@ export const drinks = sqliteTable(
   (table) => [
     index('drinks_rank_idx').on(table.rank),
     index('drinks_created_at_idx').on(table.createdAt),
+    index('drinks_updated_at_idx').on(table.updatedAt),
   ],
 );
 

--- a/app/routes/admin.drinks._index.tsx
+++ b/app/routes/admin.drinks._index.tsx
@@ -12,13 +12,15 @@ export async function loader() {
 
 type Drink = Route.ComponentProps['loaderData']['drinks'][number];
 
-type SortableColumn = 'title' | 'slug' | 'calories' | 'rank';
+type SortableColumn = 'title' | 'slug' | 'calories' | 'rank' | 'createdAt' | 'updatedAt';
 
 const SORTABLE_COLUMNS: { key: SortableColumn; label: string; align?: 'right' }[] = [
   { key: 'title', label: 'Title' },
   { key: 'slug', label: 'Slug' },
   { key: 'calories', label: 'Calories' },
   { key: 'rank', label: 'Rank' },
+  { key: 'createdAt', label: 'Created' },
+  { key: 'updatedAt', label: 'Updated' },
 ];
 
 function SortArrow({
@@ -34,6 +36,16 @@ function SortArrow({
       {isActive && sort.direction === 'desc' ? '↓' : '↑'}
     </span>
   );
+}
+
+function formatTimestamp(timestamp: Date) {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(timestamp);
 }
 
 function DrinkRow({ drink }: { drink: Drink }) {
@@ -56,6 +68,12 @@ function DrinkRow({ drink }: { drink: Drink }) {
       <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">{drink.slug}</td>
       <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">{drink.calories}</td>
       <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">{drink.rank}</td>
+      <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">
+        {formatTimestamp(drink.createdAt)}
+      </td>
+      <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">
+        {formatTimestamp(drink.updatedAt)}
+      </td>
       <td className="py-3 text-right whitespace-nowrap">
         <Link
           to={href('/admin/drinks/:slug/edit', { slug: drink.slug })}

--- a/drizzle/0001_striped_wolf_cub.sql
+++ b/drizzle/0001_striped_wolf_cub.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `drinks_updated_at_idx` ON `drinks` (`updated_at`);


### PR DESCRIPTION
Add `updatedAt` index to the drinks table and display `createdAt`/`updatedAt` in the admin drinks list, making them sortable.

---
<p><a href="https://cursor.com/agents?id=bc-b60e104d-c553-41a0-9294-937ff8e3e2bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b60e104d-c553-41a0-9294-937ff8e3e2bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

