### PR TITLE
feat: publish status

### DIFF
--- a/app/admin/drink-form.tsx
+++ b/app/admin/drink-form.tsx
@@ -1,8 +1,14 @@
 import { useRef, useState } from 'react';
 import { Form, useNavigation, useSubmit } from 'react-router';
+import { clsx } from 'clsx';
 import slugify from '@sindresorhus/slugify';
 import type { Drink } from '#/app/db/schema';
 import { ImageCrop, type ImageCropHandle } from './image-crop';
+
+const STATUS_OPTIONS: { value: Drink['status']; label: string; activeClass: string }[] = [
+  { value: 'published', label: 'Published', activeClass: 'bg-green-500/20 text-green-400' },
+  { value: 'unpublished', label: 'Unpublished', activeClass: 'bg-zinc-500/20 text-zinc-400' },
+];
 
 export function DrinkForm({
   drink,
@@ -20,6 +26,7 @@ export function DrinkForm({
   const [isSlugManuallyEdited, setIsSlugManuallyEdited] = useState(false);
   const [slugValue, setSlugValue] = useState(drink?.slug ?? '');
   const [imageRequired, setImageRequired] = useState(false);
+  const [statusValue, setStatusValue] = useState(drink?.status ?? 'published');
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -206,21 +213,27 @@ export function DrinkForm({
       </div>
 
       <div>
-        <label
-          htmlFor="status"
-          className="block text-sm font-semibold tracking-wider text-zinc-500 uppercase"
-        >
+        <span className="block text-sm font-semibold tracking-wider text-zinc-500 uppercase">
           Status
-        </label>
-        <select
-          name="status"
-          id="status"
-          defaultValue={drink?.status ?? 'published'}
-          className="mt-2 block w-full rounded-sm border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-200 focus:border-amber-600 focus:ring-1 focus:ring-amber-600 focus:outline-none"
-        >
-          <option value="published">Published</option>
-          <option value="unpublished">Unpublished</option>
-        </select>
+        </span>
+        <input type="hidden" name="status" value={statusValue} />
+        <div className="mt-2 inline-flex divide-x divide-zinc-700 rounded-sm border border-zinc-700">
+          {STATUS_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => setStatusValue(option.value)}
+              className={clsx(
+                'px-4 py-2 text-sm font-medium transition-colors',
+                statusValue === option.value
+                  ? option.activeClass
+                  : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300',
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div className="flex gap-4">

--- a/app/admin/drink-form.tsx
+++ b/app/admin/drink-form.tsx
@@ -205,6 +205,24 @@ export function DrinkForm({
         />
       </div>
 
+      <div>
+        <label
+          htmlFor="status"
+          className="block text-sm font-semibold tracking-wider text-zinc-500 uppercase"
+        >
+          Status
+        </label>
+        <select
+          name="status"
+          id="status"
+          defaultValue={drink?.status ?? 'published'}
+          className="mt-2 block w-full rounded-sm border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-200 focus:border-amber-600 focus:ring-1 focus:ring-amber-600 focus:outline-none"
+        >
+          <option value="published">Published</option>
+          <option value="unpublished">Unpublished</option>
+        </select>
+      </div>
+
       <div className="flex gap-4">
         <button
           type="submit"

--- a/app/core/errors.tsx
+++ b/app/core/errors.tsx
@@ -1,4 +1,6 @@
 import { Link, href, isRouteErrorResponse, useRouteError } from 'react-router';
+import { backgroundImageStyles } from '#/app/styles/background-image';
+import type { GuardType } from '#/app/types';
 import { NotFound } from './not-found';
 
 export function ErrorBoundary() {
@@ -11,16 +13,14 @@ export function ErrorBoundary() {
 
     return (
       <BoundaryContainer>
-        <h1>
-          <span>
-            {error.status} {error.statusText}
-          </span>
-        </h1>
-        <section className="flex flex-col gap-4">
+        <BoundaryTitle>
+          {error.status} {error.statusText}
+        </BoundaryTitle>
+        <section className="flex flex-col gap-4 text-xl">
           <p>We knew this might happen one day.</p>
           {error.data ? <p>The error message was as follows:</p> : null}
         </section>
-        {error.data ? <BoundaryError>{JSON.stringify(error.data, null, 2)}</BoundaryError> : null}
+        {error.data ? <BoundaryError>{renderRouteErrorData(error.data)}</BoundaryError> : null}
         <StartOverLink />
       </BoundaryContainer>
     );
@@ -28,16 +28,8 @@ export function ErrorBoundary() {
 
   return (
     <BoundaryContainer>
-      <h1 className="flex gap-2">
-        <span role="img" aria-hidden>
-          💥
-        </span>
-        <span>Unhandled Exception</span>
-        <span role="img" aria-hidden>
-          💥
-        </span>
-      </h1>
-      <section className="flex flex-col gap-4">
+      <BoundaryTitle emoji="💥">Unhandled Exception</BoundaryTitle>
+      <section className="flex flex-col gap-4 text-xl">
         <p>Something unexpected happened and we were not prepared. Sorry about that.</p>
         <p>The error message was as follows:</p>
       </section>
@@ -49,16 +41,35 @@ export function ErrorBoundary() {
 
 function BoundaryContainer({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex flex-col items-center gap-8 px-4 text-xl text-white md:gap-16 md:text-2xl lg:text-4xl">
+    <div className="bg-app-image flex flex-1 flex-col items-center gap-8 bg-neutral-800 bg-cover bg-fixed bg-center bg-no-repeat px-4 pt-8 text-gray-100 md:gap-16 md:pt-24">
+      <style dangerouslySetInnerHTML={{ __html: backgroundImageStyles }} />
       {children}
     </div>
   );
 }
 
+function BoundaryTitle({ emoji, children }: { emoji?: string; children: React.ReactNode }) {
+  return (
+    <h1 className="flex gap-4 text-4xl font-normal">
+      {emoji ? (
+        <span role="img" aria-hidden>
+          {emoji}
+        </span>
+      ) : null}
+      {children}
+      {emoji ? (
+        <span role="img" aria-hidden>
+          {emoji}
+        </span>
+      ) : null}
+    </h1>
+  );
+}
+
 function BoundaryError({ children }: { children: React.ReactNode }) {
   return (
-    <pre className="w-full bg-stone-900 p-8">
-      <code className="align-middle text-xl">{children}</code>
+    <pre className="w-full max-w-7xl bg-stone-900 p-12 whitespace-pre-wrap">
+      <code className="text-base">{children}</code>
     </pre>
   );
 }
@@ -73,4 +84,12 @@ function StartOverLink() {
       Try Starting Over
     </Link>
   );
+}
+
+function renderRouteErrorData(routeErrorData: GuardType<typeof isRouteErrorResponse>['data']) {
+  if (typeof routeErrorData === 'object') {
+    return JSON.stringify(routeErrorData, null, 2);
+  }
+
+  return String(routeErrorData);
 }

--- a/app/core/not-found.tsx
+++ b/app/core/not-found.tsx
@@ -1,9 +1,11 @@
 import { Link, href } from 'react-router';
 import { Icon } from '#/app/icons/icon';
+import { backgroundImageStyles } from '#/app/styles/background-image';
 
 export function NotFound() {
   return (
-    <div className="m-4 flex flex-col items-center justify-evenly text-gray-100 md:mx-0 md:mt-8 md:mb-0">
+    <div className="bg-app-image flex flex-1 flex-col items-center justify-evenly bg-neutral-800 bg-cover bg-fixed bg-center bg-no-repeat text-gray-100">
+      <style dangerouslySetInnerHTML={{ __html: backgroundImageStyles }} />
       <p className="max-w-[23ch] text-center text-xl font-normal md:text-2xl md:font-light lg:text-4xl">
         Oops, this doesn&apos;t appear to be a tasty drink recipe!
       </p>

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -29,6 +29,7 @@ export const drinks = sqliteTable(
     tags: text('tags', { mode: 'json' }).notNull().$type<string[]>(),
     notes: text('notes'),
     rank: integer('rank').notNull().default(0),
+    status: text('status').notNull().$type<'published' | 'unpublished'>().default('published'),
     createdAt: integer('created_at', { mode: 'timestamp' })
       .notNull()
       .default(sql`(unixepoch())`),

--- a/app/models/drink.server.ts
+++ b/app/models/drink.server.ts
@@ -10,6 +10,14 @@ export async function getAllDrinks(): Promise<Drink[]> {
   });
 }
 
+export async function getPublishedDrinks(): Promise<Drink[]> {
+  const db = getDb();
+  return db.query.drinks.findMany({
+    where: eq(drinks.status, 'published'),
+    orderBy: [desc(drinks.rank), desc(drinks.createdAt)],
+  });
+}
+
 export async function getDrinkBySlug(slug: Drink['slug']): Promise<Drink | undefined> {
   const db = getDb();
   return db.query.drinks.findFirst({
@@ -20,21 +28,23 @@ export async function getDrinkBySlug(slug: Drink['slug']): Promise<Drink | undef
 export async function getDrinksByTag(tag: string): Promise<Drink[]> {
   const db = getDb();
   // Query drinks where tags JSON array contains the tag
-  const allDrinks = await db.query.drinks.findMany({
+  const publishedDrinks = await db.query.drinks.findMany({
+    where: eq(drinks.status, 'published'),
     orderBy: [desc(drinks.rank), desc(drinks.createdAt)],
   });
 
-  return allDrinks.filter((drink) => drink.tags.includes(tag));
+  return publishedDrinks.filter((drink) => drink.tags.includes(tag));
 }
 
 export async function getAllTags(): Promise<string[]> {
   const db = getDb();
-  const allDrinks = await db.query.drinks.findMany({
+  const publishedDrinks = await db.query.drinks.findMany({
+    where: eq(drinks.status, 'published'),
     columns: { tags: true },
   });
 
   const tagSet = new Set<string>();
-  for (const drink of allDrinks) {
+  for (const drink of publishedDrinks) {
     for (const tag of drink.tags) {
       tagSet.add(tag);
     }

--- a/app/routes/_app._index.tsx
+++ b/app/routes/_app._index.tsx
@@ -2,7 +2,7 @@ import { data } from 'react-router';
 import { cacheHeader } from 'pretty-cache-header';
 import { defaultPageDescription, defaultPageTitle } from '#/app/core/config';
 import { DrinkList } from '#/app/drinks/drink-list';
-import { getAllDrinks } from '#/app/models/drink.server';
+import { getPublishedDrinks } from '#/app/models/drink.server';
 import { getEnvVars } from '#/app/utils/env.server';
 import { withPlaceholderImages } from '#/app/utils/placeholder-images.server';
 import type { Route } from './+types/_app._index';
@@ -14,7 +14,7 @@ export function headers({ loaderHeaders }: Route.HeadersArgs) {
 }
 
 export async function loader() {
-  const drinks = await getAllDrinks();
+  const drinks = await getPublishedDrinks();
   const drinksWithPlaceholderImages = await withPlaceholderImages(drinks);
 
   return data(

--- a/app/routes/admin.drinks._index.tsx
+++ b/app/routes/admin.drinks._index.tsx
@@ -12,13 +12,21 @@ export async function loader() {
 
 type Drink = Route.ComponentProps['loaderData']['drinks'][number];
 
-type SortableColumn = 'title' | 'slug' | 'calories' | 'rank' | 'createdAt' | 'updatedAt';
+type SortableColumn =
+  | 'title'
+  | 'slug'
+  | 'calories'
+  | 'rank'
+  | 'status'
+  | 'createdAt'
+  | 'updatedAt';
 
 const SORTABLE_COLUMNS: { key: SortableColumn; label: string; align?: 'right' }[] = [
   { key: 'title', label: 'Title' },
   { key: 'slug', label: 'Slug' },
   { key: 'calories', label: 'Calories' },
   { key: 'rank', label: 'Rank' },
+  { key: 'status', label: 'Status' },
   { key: 'createdAt', label: 'Created' },
   { key: 'updatedAt', label: 'Updated' },
 ];
@@ -68,6 +76,18 @@ function DrinkRow({ drink }: { drink: Drink }) {
       <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">{drink.slug}</td>
       <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">{drink.calories}</td>
       <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">{drink.rank}</td>
+      <td className="py-3 pr-4 whitespace-nowrap">
+        <span
+          className={clsx(
+            'inline-block rounded px-2 py-0.5 text-xs font-medium',
+            drink.status === 'published'
+              ? 'bg-green-500/20 text-green-400'
+              : 'bg-zinc-500/20 text-zinc-400',
+          )}
+        >
+          {drink.status}
+        </span>
+      </td>
       <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">
         {formatTimestamp(drink.createdAt)}
       </td>

--- a/app/routes/admin.drinks._index.tsx
+++ b/app/routes/admin.drinks._index.tsx
@@ -12,14 +12,7 @@ export async function loader() {
 
 type Drink = Route.ComponentProps['loaderData']['drinks'][number];
 
-type SortableColumn =
-  | 'title'
-  | 'slug'
-  | 'calories'
-  | 'rank'
-  | 'status'
-  | 'createdAt'
-  | 'updatedAt';
+type SortableColumn = 'title' | 'slug' | 'calories' | 'rank' | 'status' | 'createdAt' | 'updatedAt';
 
 const SORTABLE_COLUMNS: { key: SortableColumn; label: string; align?: 'right' }[] = [
   { key: 'title', label: 'Title' },

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -32,7 +32,7 @@ export default function AdminLayout({ loaderData }: Route.ComponentProps) {
   return (
     <div className="min-h-screen bg-zinc-950">
       <header className="border-b border-zinc-800 bg-zinc-900">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-3">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3">
           <div className="flex items-center gap-1">
             <Link to={href('/')} className="text-zinc-400 hover:text-white">
               drinks.fyi
@@ -53,7 +53,7 @@ export default function AdminLayout({ loaderData }: Route.ComponentProps) {
         </div>
       </header>
       <title>Admin | drinks.fyi</title>
-      <main className="mx-auto max-w-5xl px-6 py-8">
+      <main className="mx-auto max-w-7xl px-6 py-8">
         <Outlet />
       </main>
       <Toaster toastOptions={{ className: 'text-sm! sm:w-auto!' }} richColors />

--- a/app/search/cache.server.ts
+++ b/app/search/cache.server.ts
@@ -1,5 +1,5 @@
 import { remember, forget } from '@epic-web/remember';
-import { getAllDrinks } from '#/app/models/drink.server';
+import { getPublishedDrinks } from '#/app/models/drink.server';
 import type { Drink } from '#/app/db/schema';
 import { createSearchIndex } from '#/app/search/minisearch.server';
 
@@ -12,11 +12,11 @@ type SearchData = {
 
 /**
  * Get the cached MiniSearch instance and allDrinks data, creating them if they don't exist
- * (which fetches all drinks from SQLite).
+ * (which fetches all published drinks from SQLite).
  */
 export async function getSearchData(): Promise<SearchData> {
   return remember(SEARCH_INSTANCE_CACHE_KEY, async () => {
-    const allDrinks = await getAllDrinks();
+    const allDrinks = await getPublishedDrinks();
     const searchIndex = createSearchIndex(allDrinks);
 
     return { allDrinks, searchIndex };

--- a/app/types.ts
+++ b/app/types.ts
@@ -14,3 +14,12 @@ export type EnhancedDrink = {
 // semantically different and it may end up an intersection of multiple types in
 // the future.
 export type AppRouteHandle = BreadcrumbHandle;
+
+/**
+ * Extracts the narrowed type from a type guard function.
+ *
+ * @see https://stackoverflow.com/a/75638165
+ */
+export type GuardType<TypeGuardFn> = TypeGuardFn extends (x: any, ...rest: any) => x is infer U
+  ? U
+  : never;

--- a/app/validation/drink.ts
+++ b/app/validation/drink.ts
@@ -37,4 +37,5 @@ export const drinkFormSchema = z.object({
   tags: commaSeparatedList.pipe(z.array(z.string()).min(1, 'At least one tag is required')),
   notes: trimmedString.transform((value) => value || null),
   rank: intFromString.pipe(z.int('Rank must be a whole number')),
+  status: z.enum(['published', 'unpublished']),
 });

--- a/drizzle/0001_condemned_centennial.sql
+++ b/drizzle/0001_condemned_centennial.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `drinks` ADD `status` text DEFAULT 'published' NOT NULL;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,207 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dc2b4d12-dc8c-4701-992a-13e1f2903203",
+  "prevId": "940becaa-ff9b-4598-9d82-557551df5375",
+  "tables": {
+    "drinks": {
+      "name": "drinks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_file_id": {
+          "name": "image_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ingredients": {
+          "name": "ingredients",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'published'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "drinks_slug_unique": {
+          "name": "drinks_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        },
+        "drinks_rank_idx": {
+          "name": "drinks_rank_idx",
+          "columns": ["rank"],
+          "isUnique": false
+        },
+        "drinks_created_at_idx": {
+          "name": "drinks_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771174809132,
       "tag": "0000_supreme_micromacro",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1771701821280,
+      "tag": "0001_condemned_centennial",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Implement published/unpublished functionality for drinks to control their visibility on public routes.

This PR introduces a `status` field to the `drinks` schema, allowing drinks to be marked as 'published' or 'unpublished'. Public-facing routes (home, tags, search) now only display published drinks, while admin routes continue to show all drinks, including a new status column and a dropdown for managing the status in the drink form.

---
<p><a href="https://cursor.com/agents?id=bc-747dbcd1-baa2-4cb9-8d13-20e3c8ba9158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-747dbcd1-baa2-4cb9-8d13-20e3c8ba9158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

