### PR TITLE
fix: return 404 for unpublished drinks

### DIFF
--- a/app/routes/_app.$slug.tsx
+++ b/app/routes/_app.$slug.tsx
@@ -19,7 +19,7 @@ export function headers({ loaderHeaders }: Route.HeadersArgs) {
 export async function loader({ params }: Route.LoaderArgs) {
   const sqliteDrink = await getDrinkBySlug(params.slug ?? '');
 
-  invariantResponse(sqliteDrink, 'Drink not found', {
+  const notFoundHeaders = {
     status: 404,
     headers: {
       'Surrogate-Key': 'all',
@@ -30,7 +30,10 @@ export async function loader({ params }: Route.LoaderArgs) {
         mustRevalidate: true,
       }),
     },
-  });
+  };
+
+  invariantResponse(sqliteDrink, 'Drink not found', notFoundHeaders);
+  invariantResponse(sqliteDrink.status === 'published', 'Drink not found', notFoundHeaders);
 
   const [enhancedDrink] = await withPlaceholderImages([sqliteDrink]);
 


### PR DESCRIPTION
## Summary
- Unpublished drinks now return 404 on the public detail page (`/:slug`), closing a gap from #261 where direct URL access still served unpublished drinks

## Test plan
- [ ] Set a drink to unpublished via admin, verify its direct URL returns 404
- [ ] Set it back to published, verify the page loads again

🤖 Generated with [Claude Code](https://claude.com/claude-code)