### PR TITLE
fix: targeted surrogate purges + reduce 404 TTL

### DIFF
--- a/app/routes/_app.$.tsx
+++ b/app/routes/_app.$.tsx
@@ -16,7 +16,7 @@ export function headers() {
     'Cache-Control': cacheHeader({
       public: true,
       maxAge: '30sec',
-      sMaxage: '5min',
+      sMaxage: '1min',
       mustRevalidate: true,
     }),
   };

--- a/app/routes/_app.$slug.tsx
+++ b/app/routes/_app.$slug.tsx
@@ -26,7 +26,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       'Cache-Control': cacheHeader({
         public: true,
         maxAge: '30sec',
-        sMaxage: '5min',
+        sMaxage: '1min',
         mustRevalidate: true,
       }),
     },

--- a/app/routes/_app.tags.$tag.tsx
+++ b/app/routes/_app.tags.$tag.tsx
@@ -29,7 +29,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       'Cache-Control': cacheHeader({
         public: true,
         maxAge: '30sec',
-        sMaxage: '5min',
+        sMaxage: '1min',
         mustRevalidate: true,
       }),
     },

--- a/app/utils/fastly.server.ts
+++ b/app/utils/fastly.server.ts
@@ -23,10 +23,10 @@ async function purgeFastlyCache(surrogateKeys: string[]): Promise<void> {
 }
 
 /**
- * Purge all cache keys affected by a drink change.
- * Aligns with existing surrogate key patterns in the codebase.
+ * Purge targeted cache keys affected by a drink change.
+ * The `all` key is intentionally excluded here; it is only purged on deploy.
  */
 export async function purgeDrinkCache(drink: { slug: string; tags: string[] }): Promise<void> {
-  const keys = ['index', 'all', drink.slug, 'tags', ...drink.tags.map(getSurrogateKeyForTag)];
+  const keys = ['index', drink.slug, 'tags', ...drink.tags.map(getSurrogateKeyForTag)];
   await purgeFastlyCache(keys);
 }


### PR DESCRIPTION
## Summary

- Remove `all` from `purgeDrinkCache()` so admin writes (create/update/delete) only invalidate affected surrogate keys (`index`, drink slug, `tags`, individual tag keys) instead of the entire CDN cache
- Reduce 404 CDN TTL from 5 minutes to 1 minute across all public routes (`_app.$slug`, `_app.tags.$tag`, `_app.$`) so stale 404s clear quickly when new content is published at a previously-missing slug
- The `all` key continues to be purged on production deploys via CI workflow

## Test plan

- [ ] Verify CI passes (lint, typecheck, format)
- [ ] Deploy and confirm creating/editing a drink purges only the relevant pages (index, drink slug, tags) and not the entire cache
- [ ] Visit a non-existent slug, confirm the 404 response has `s-maxage=60` (1 minute)
- [ ] Create a drink at that slug, confirm the 404 clears within ~1 minute without a full cache purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)