### PR TITLE
feat: add surrogate key caching to search results

### DIFF
--- a/app/utils/fastly.server.ts
+++ b/app/utils/fastly.server.ts
@@ -27,6 +27,6 @@ async function purgeFastlyCache(surrogateKeys: string[]): Promise<void> {
  * The `all` key is intentionally excluded here; it is only purged on deploy.
  */
 export async function purgeDrinkCache(drink: { slug: string; tags: string[] }): Promise<void> {
-  const keys = ['index', drink.slug, 'tags', ...drink.tags.map(getSurrogateKeyForTag)];
+  const keys = ['index', 'search', drink.slug, 'tags', ...drink.tags.map(getSurrogateKeyForTag)];
   await purgeFastlyCache(keys);
 }


### PR DESCRIPTION
## Summary

- Add `Surrogate-Key: search all` and `Cache-Control` headers to search result responses (both with and without results) so Fastly can cache them
- Add `search` to the surrogate keys purged in `purgeDrinkCache()` so cached search results are invalidated on drink mutations

## Test plan

- [ ] Visit `/search` (no query) and verify `Surrogate-Key: all` header is present (no `search` key — this page is just UI with no drink data)
- [ ] Visit `/search?q=margarita` and verify `Surrogate-Key: search all` and `Cache-Control` headers are present
- [ ] Visit `/search?q=nonexistent` (no results) and verify the same headers are present
- [ ] Create/update/delete a drink in admin and verify the Fastly purge request includes the `search` surrogate key

🤖 Generated with [Claude Code](https://claude.com/claude-code)