### PR TITLE
chore: remove .cursor directory

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,5 +1,0 @@
-{
-  "setup-worktree": [
-    "npm install"
-  ]
-}


### PR DESCRIPTION
## Summary
- Remove checked-in `.cursor` directory (contained `worktrees.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)