### PR TITLE
ci(renovate): use glob syntax for identifying Dockerfile variants

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["Dockerfile", "Dockerfile\\..+"],
+      "managerFilePatterns": ["Dockerfile", "Dockerfile.*"],
       "matchStrings": ["npm install -g pnpm@(?<currentValue>[^\\s]+)"],
       "depNameTemplate": "pnpm",
       "datasourceTemplate": "npm"


### PR DESCRIPTION
The previous pattern did not match `Dockerfile.dev` (for example).