### PR TITLE
feat: link drink titles in admin list to their public page

### DIFF
--- a/app/routes/admin.drinks._index.tsx
+++ b/app/routes/admin.drinks._index.tsx
@@ -63,7 +63,12 @@ function DrinkRow({ drink }: { drink: Drink }) {
             alt=""
             className="rounded object-cover"
           />
-          <span className="font-medium text-zinc-300">{drink.title}</span>
+          <Link
+            to={href("/:slug", { slug: drink.slug })}
+            className="font-medium text-zinc-300 hover:text-amber-500"
+          >
+            {drink.title}
+          </Link>
         </div>
       </td>
       <td className="py-3 pr-4 whitespace-nowrap text-zinc-400">{drink.slug}</td>


### PR DESCRIPTION
## Summary
- Wraps drink titles in the admin drinks list with a Link to their public page (`/:slug`)
- Adds amber hover style consistent with existing action links

## Test plan
- [x] Navigate to admin drinks list
- [x] Verify each drink title is clickable and navigates to the correct public drink page
- [x] Verify hover style matches existing link styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)