### PR TITLE
feat: allow admins to view unpublished drink detail pages

### DIFF
--- a/app/middleware/authorization.server.ts
+++ b/app/middleware/authorization.server.ts
@@ -92,8 +92,12 @@ export const optionalUserMiddleware: MiddlewareFunction<Response> = async (
         avatarUrl: user.avatarUrl,
         role: user.role,
       });
+
+      return next();
     }
   }
+
+  context.set(optionalUserContext, undefined);
 
   return next();
 };

--- a/app/middleware/authorization.server.ts
+++ b/app/middleware/authorization.server.ts
@@ -11,6 +11,7 @@ import { createReturnToUrl } from "#/app/auth/utils.server";
 import type { AuthenticatedUser } from "#/app/auth/types";
 
 const userContext = createContext<AuthenticatedUser>();
+const optionalUserContext = createContext<AuthenticatedUser | undefined>(undefined);
 
 /**
  * Get the authenticated user from the route context.
@@ -53,6 +54,46 @@ export const userMiddleware: MiddlewareFunction<Response> = async ({ request, co
     avatarUrl: user.avatarUrl,
     role: user.role,
   });
+
+  return next();
+};
+
+/**
+ * Get the optionally-authenticated user from the route context.
+ * Returns undefined if no user is logged in.
+ * Use this in route loaders/actions after optionalUserMiddleware has run.
+ */
+export function getOptionalUserFromContext(
+  context: Readonly<RouterContextProvider>,
+): AuthenticatedUser | undefined {
+  return context.get(optionalUserContext);
+}
+
+/**
+ * Middleware that optionally populates user context. If a valid session exists
+ * and the user still exists in the database, the user is stored in context.
+ * Never redirects or throws — always calls next.
+ */
+export const optionalUserMiddleware: MiddlewareFunction<Response> = async (
+  { request, context },
+  next,
+) => {
+  const session = await getSession(request.headers.get("Cookie"));
+  const sessionUser = session.get("user");
+
+  if (sessionUser) {
+    const user = await getUserById(sessionUser.id);
+
+    if (user) {
+      context.set(optionalUserContext, {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        avatarUrl: user.avatarUrl,
+        role: user.role,
+      });
+    }
+  }
 
   return next();
 };

--- a/app/middleware/authorization.test.ts
+++ b/app/middleware/authorization.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import type { RouterContextProvider } from "react-router";
+import { resetAndSeedDatabase } from "#/app/db/reset.server";
+import { commitSession, getSession } from "#/app/auth/session.server";
+import {
+  optionalUserMiddleware,
+  getOptionalUserFromContext,
+} from "#/app/middleware/authorization.server";
+import { TEST_ADMIN_USER } from "#/playwright/seed-data";
+import type { AuthenticatedUser } from "#/app/auth/types";
+
+beforeEach(async () => {
+  await resetAndSeedDatabase();
+});
+
+function createMockContext(): RouterContextProvider {
+  const map = new Map<unknown, unknown>();
+  return {
+    get: (key: unknown) => map.get(key),
+    set: (key: unknown, value: unknown) => map.set(key, value),
+  } as unknown as RouterContextProvider;
+}
+
+async function createSessionCookie(user: AuthenticatedUser): Promise<string> {
+  const session = await getSession();
+  session.set("user", user);
+  return commitSession(session);
+}
+
+describe("optionalUserMiddleware", () => {
+  test("sets user in context when valid session exists", async () => {
+    const cookie = await createSessionCookie({
+      id: TEST_ADMIN_USER.id,
+      email: TEST_ADMIN_USER.email,
+      name: TEST_ADMIN_USER.name!,
+      avatarUrl: TEST_ADMIN_USER.avatarUrl ?? null,
+      role: TEST_ADMIN_USER.role ?? "user",
+    });
+
+    const request = new Request("http://localhost/test", {
+      headers: { Cookie: cookie },
+    });
+
+    const context = createMockContext();
+    let nextCalled = false;
+    const next = async () => {
+      nextCalled = true;
+      return new Response();
+    };
+
+    await optionalUserMiddleware({ request, context } as never, next);
+
+    expect(nextCalled).toBe(true);
+    const user = getOptionalUserFromContext(context);
+    expect(user).toBeDefined();
+    expect(user!.id).toBe(TEST_ADMIN_USER.id);
+    expect(user!.role).toBe("admin");
+  });
+
+  test("calls next without setting user when no session", async () => {
+    const request = new Request("http://localhost/test");
+    const context = createMockContext();
+    let nextCalled = false;
+    const next = async () => {
+      nextCalled = true;
+      return new Response();
+    };
+
+    await optionalUserMiddleware({ request, context } as never, next);
+
+    expect(nextCalled).toBe(true);
+    expect(getOptionalUserFromContext(context)).toBeUndefined();
+  });
+
+  test("calls next without setting user when user no longer exists in db", async () => {
+    const cookie = await createSessionCookie({
+      id: "nonexistent-user-id",
+      email: "ghost@test.com",
+      name: "Ghost",
+      avatarUrl: null,
+      role: "admin",
+    });
+
+    const request = new Request("http://localhost/test", {
+      headers: { Cookie: cookie },
+    });
+
+    const context = createMockContext();
+    let nextCalled = false;
+    const next = async () => {
+      nextCalled = true;
+      return new Response();
+    };
+
+    await optionalUserMiddleware({ request, context } as never, next);
+
+    expect(nextCalled).toBe(true);
+    expect(getOptionalUserFromContext(context)).toBeUndefined();
+  });
+});

--- a/app/routes/_app.$slug.tsx
+++ b/app/routes/_app.$slug.tsx
@@ -9,6 +9,7 @@ import { DrinkDetails } from "#/app/drinks/drink-details";
 import { getDrinkBySlug } from "#/app/models/drink.server";
 import { markdownToHtml } from "#/app/utils/markdown.server";
 import { withPlaceholderImages } from "#/app/utils/placeholder-images.server";
+import { getOptionalUserFromContext } from "#/app/middleware/authorization.server";
 import type { AppRouteHandle } from "#/app/types";
 import type { Route } from "./+types/_app.$slug";
 
@@ -16,7 +17,7 @@ export function headers({ loaderHeaders }: Route.HeadersArgs) {
   return loaderHeaders;
 }
 
-export async function loader({ params }: Route.LoaderArgs) {
+export async function loader({ params, context }: Route.LoaderArgs) {
   const sqliteDrink = await getDrinkBySlug(params.slug ?? "");
 
   const notFoundHeaders = {
@@ -33,7 +34,13 @@ export async function loader({ params }: Route.LoaderArgs) {
   };
 
   invariantResponse(sqliteDrink, "Drink not found", notFoundHeaders);
-  invariantResponse(sqliteDrink.status === "published", "Drink not found", notFoundHeaders);
+
+  const optionalUser = getOptionalUserFromContext(context);
+  const isAdmin = optionalUser?.role === "admin";
+
+  if (!isAdmin) {
+    invariantResponse(sqliteDrink.status === "published", "Drink not found", notFoundHeaders);
+  }
 
   const [enhancedDrink] = await withPlaceholderImages([sqliteDrink]);
 
@@ -41,21 +48,23 @@ export async function loader({ params }: Route.LoaderArgs) {
     enhancedDrink.notes = markdownToHtml(enhancedDrink.notes);
   }
 
-  return data(
-    { drink: enhancedDrink },
-    {
-      headers: {
-        "Surrogate-Key": `all ${enhancedDrink.slug}`,
-        "Cache-Control": cacheHeader({
-          public: true,
-          maxAge: "30sec",
-          sMaxage: "1yr",
-          staleWhileRevalidate: "10min",
-          staleIfError: "1day",
-        }),
-      },
-    },
-  );
+  const responseHeaders: Record<string, string> =
+    sqliteDrink.status === "published"
+      ? {
+          "Surrogate-Key": `all ${enhancedDrink.slug}`,
+          "Cache-Control": cacheHeader({
+            public: true,
+            maxAge: "30sec",
+            sMaxage: "1yr",
+            staleWhileRevalidate: "10min",
+            staleIfError: "1day",
+          }),
+        }
+      : {
+          "Cache-Control": cacheHeader({ private: true, noStore: true }),
+        };
+
+  return data({ drink: enhancedDrink }, { headers: responseHeaders });
 }
 
 export const handle: AppRouteHandle = {

--- a/app/routes/_app.tsx
+++ b/app/routes/_app.tsx
@@ -4,8 +4,11 @@ import { Breadcrumbs } from "#/app/navigation/breadcrumbs";
 import { SkipNavLink } from "#/app/core/skip-nav-link";
 import { Header } from "#/app/core/header";
 import { Footer } from "#/app/core/footer";
+import { optionalUserMiddleware } from "#/app/middleware/authorization.server";
 import type { AppRouteHandle } from "#/app/types";
 import type { Route } from "./+types/_app";
+
+export const middleware = [optionalUserMiddleware];
 
 // This pathless layout route wraps all public-facing routes with the site chrome (Header,
 // Breadcrumbs, Footer, background image, etc.). It also renders an error fallback for any errors


### PR DESCRIPTION
## Summary
- Add `optionalUserMiddleware` to the `_app` layout so all public routes can detect logged-in admins
- Skip the published status check in the drink detail loader when the viewer is an admin
- Use `private, no-store` cache headers for unpublished drink responses to prevent CDN leaks
- Add unit tests for the new middleware (valid session, no session, deleted user)

## Test plan
- [x] Log in as admin, navigate to an unpublished drink's slug — should render normally
- [x] Log out, navigate to the same slug — should 404
- [x] Log in as non-admin user, navigate to the same slug — should 404
- [x] Published drinks continue to work for all visitors
- [x] `pnpm lint && pnpm typecheck && pnpm format && npx vitest run` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)