### PR TITLE
fix: prevent focus ring clipping in admin drink list

### DIFF
--- a/app/routes/admin.drinks._index.tsx
+++ b/app/routes/admin.drinks._index.tsx
@@ -123,7 +123,7 @@ export default function AdminDrinksList({ loaderData }: Route.ComponentProps) {
   const { processed, filter, setFilter, sort, handleSort } = useSortableData(drinks);
 
   return (
-    <div>
+    <div className="p-1">
       <title>All Drinks | drinks.fyi</title>
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-baseline gap-2">

--- a/app/routes/admin.drinks._index.tsx
+++ b/app/routes/admin.drinks._index.tsx
@@ -123,7 +123,7 @@ export default function AdminDrinksList({ loaderData }: Route.ComponentProps) {
   const { processed, filter, setFilter, sort, handleSort } = useSortableData(drinks);
 
   return (
-    <div className="p-1">
+    <div>
       <title>All Drinks | drinks.fyi</title>
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-baseline gap-2">
@@ -152,7 +152,7 @@ export default function AdminDrinksList({ loaderData }: Route.ComponentProps) {
         className="mb-4 w-full rounded-sm border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-200 placeholder-zinc-600 focus:border-amber-600 focus:ring-1 focus:ring-amber-600 focus:outline-none"
       />
 
-      <div className="overflow-x-auto">
+      <div className="-m-2 overflow-x-auto p-2">
         <table className="w-full min-w-max">
           <thead>
             <tr className="border-b border-zinc-800 text-left text-sm tracking-wider text-zinc-500 uppercase">


### PR DESCRIPTION
## Summary
- Add padding with compensating negative margin (`-m-2 p-2`) to the `overflow-x-auto` table container so focus outlines render inside the overflow boundary instead of being clipped

## Test plan
- [ ] Tab through column header sort buttons — focus ring fully visible on all sides
- [ ] Tab to Edit/Delete actions in table rows — no clipping at edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)