### PR TITLE
refactor: extract admin drink write workflow

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -23,24 +23,31 @@
 
 ## Architecture seams
 
-| Term                      | Definition                                                                                                                                            | Aliases to avoid                           |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| **Module**                | A domain-owned folder under `app/modules/<module>` with a narrow public interface and hidden internals.                                               | Feature folder, layer                      |
-| **Deep module**           | A **Module** whose **Public seam** is small relative to the complexity it hides; behavior is pinned with **Boundary tests**.                          | Feature dump, leaky barrel                 |
-| **Public entrypoint**     | One of the two allowed import surfaces for a module: `<module>.ts` or `<module>.server.ts`.                                                           | Barrel, shared file                        |
-| **Public seam**           | The full public API exposed by a module through its public entrypoints.                                                                               | Public surface, exported helpers           |
-| **Module internals**      | Any file inside a module that is not a public entrypoint.                                                                                             | Helpers, private API                       |
-| **Boundary dependency**   | An external effect or collaborator that crosses a real system boundary and is passed into a service factory.                                          | Injectable helper, override hook           |
-| **Mutation boundary**     | A boundary dependency required only when the service performs create, update, or delete (e.g. hosted images, edge cache invalidation).                | Write effects, write ports, I/O hooks      |
-| **Internal collaborator** | A module-private helper used inside the implementation and not exposed through the public seam.                                                       | Injectable internal, test seam             |
-| **Service**               | The single object returned by `create<Module>Service(...)` that exposes the module’s public behavior—not split into separate read and write services. | Manager, util, read service, write service |
-| **Capability method**     | A public service operation named for what it does rather than for a route or page.                                                                    | Page method, route method                  |
-| **Draft**                 | Validated input data shaped for saving through a service.                                                                                             | Form data, payload                         |
-| **Editor**                | Data for create or edit UI, including initial values and options.                                                                                     | View model, form model                     |
-| **Route action**          | The standard action pipeline that validates input, dispatches intent, translates domain errors, and handles toasts or redirects.                      | Action helper, form handler                |
-| **Domain error**          | A typed expected failure raised by a module for business-rule violations.                                                                             | Result union, error string                 |
-| **Warning metadata**      | Non-fatal follow-up information returned with a successful operation.                                                                                 | Soft error, partial failure                |
-| **Boundary test**         | A test that exercises a module through its public schema or service API.                                                                              | Unit test of internals, helper test        |
+| Term                           | Definition                                                                                                                                            | Aliases to avoid                           |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| **Module**                     | A domain-owned folder under `app/modules/<module>` with a narrow public interface and hidden internals.                                               | Feature folder, layer                      |
+| **Deep module**                | A **Module** whose **Public seam** is small relative to the complexity it hides; behavior is pinned with **Boundary tests**.                          | Feature dump, leaky barrel                 |
+| **Public entrypoint**          | One of the two allowed import surfaces for a module: `<module>.ts` or `<module>.server.ts`.                                                           | Barrel, shared file                        |
+| **Public seam**                | The full public API exposed by a module through its public entrypoints.                                                                               | Public surface, exported helpers           |
+| **Module internals**           | Any file inside a module that is not a public entrypoint.                                                                                             | Helpers, private API                       |
+| **Boundary dependency**        | An external effect or collaborator that crosses a real system boundary and is passed into a service factory.                                          | Injectable helper, override hook           |
+| **Mutation boundary**          | A boundary dependency required only when the service performs create, update, or delete (e.g. hosted images, edge cache invalidation).                | Write effects, write ports, I/O hooks      |
+| **Internal collaborator**      | A module-private helper used inside the implementation and not exposed through the public seam.                                                       | Injectable internal, test seam             |
+| **Service**                    | The single object returned by `create<Module>Service(...)` that exposes the module’s public behavior—not split into separate read and write services. | Manager, util, read service, write service |
+| **Capability method**          | A public service operation named for what it does rather than for a route or page.                                                                    | Page method, route method                  |
+| **Draft**                      | Validated input data shaped for saving through a service.                                                                                             | Form data, payload                         |
+| **Editor**                     | Data for create or edit UI, including initial values and options.                                                                                     | View model, form model                     |
+| **Route action**               | The standard action pipeline that validates input, dispatches intent, translates domain errors, and handles toasts or redirects.                      | Action helper, form handler                |
+| **Route Action Seam**          | The explicit route-level call to `routeAction(...)` that remains visible even when app-specific orchestration is extracted.                           | Hidden action handler, implicit workflow   |
+| **Workflow**                   | A domain-specific application layer that coordinates a user-facing operation across framework seams and module capabilities.                          | Wiring, generic helper, domain core        |
+| **Admin Drink Write Path**     | The admin-only capability for creating, updating, and deleting a **Drink** from route submissions.                                                    | Save flow, admin mutation layer            |
+| **Admin Drink Write Workflow** | The **Workflow** dedicated to the **Admin Drink Write Path** that prepares create, update, and delete operations for the **Route Action Seam**.       | Generic form workflow, drinks domain core  |
+| **Preparation Failure**        | A non-navigational submission failure detected before the **Route Action Seam** and represented as validation-shaped errors.                          | Arbitrary response, thrown redirect        |
+| **Prepared Intent**            | A fully-built `Intent` produced by a **Workflow** and handed to the **Route Action Seam** for execution.                                              | Partial route config, ad hoc action policy |
+| **Framework Adapter**          | A thin layer that absorbs framework-specific request mechanics without changing the router-agnostic business service.                                 | Domain service, business core              |
+| **Domain error**               | A typed expected failure raised by a module for business-rule violations.                                                                             | Result union, error string                 |
+| **Warning metadata**           | Non-fatal follow-up information returned with a successful operation.                                                                                 | Soft error, partial failure                |
+| **Boundary test**              | A test that exercises a module through its public schema or service API.                                                                              | Unit test of internals, helper test        |
 
 ## Relationships
 
@@ -57,22 +64,26 @@
 - A module has one **Service**; read-only call sites may construct it with only the database, while mutation call sites pass **Mutation boundaries** into the same factory shape—no second **Service** type or “writer” object.
 - Mutating routes may pass **Mutation boundaries** inline at `createDrinksService(...)` instead of a separate app-level helper; that is still one **Service**, not a read/write split.
 - A **Route action** validates a **Draft**, calls a **Service**, and translates **Domain errors**.
+- The **Admin Drink Write Path** passes through the **Route Action Seam**.
+- The **Admin Drink Write Workflow** coordinates the **Admin Drink Write Path** while the **Drinks** **Service** remains the business core underneath it.
+- A **Preparation Failure** may occur before a **Prepared Intent** reaches the **Route Action Seam**.
+- A **Framework Adapter** may change when the router changes, but the underlying **Service** should not.
 - **Warning metadata** may accompany a successful create, update, or delete when follow-up cleanup only partially succeeds.
 - A **Deep module** keeps integration detail behind the **Public seam**; callers and **Boundary tests** depend on the **Service** and schemas, not **Module internals**.
 
 ## Example dialogue
 
-> **Dev:** "The type is called `DrinkView` in code. Is that only for **Published drink**s?"
+> **Dev:** "If we extract the admin save logic, should the route stop calling `routeAction(...)`?"
 >
-> **Domain expert:** "No. **Drink view** is how we _present_ a **Drink** in the gallery—image, notes, tags. **Published drink** vs **Unpublished drink** is who may see which rows. An **Admin** loading an **Unpublished drink** on the slug page still gets a **Drink view** inside **Drink for viewer**, with private visibility."
+> **Domain expert:** "No — keep the **Route Action Seam** visible. The route should execute a **Prepared Intent**, not rebuild policy itself."
 >
-> **Dev:** "So search is different?"
+> **Dev:** "So where does the duplicated create/edit/delete orchestration go?"
 >
-> **Domain expert:** "**Search result**s are always **Published drink**s, so every hit is both a **Published drink** and shown as a **Drink view**. The name _published_ belongs on that query, not on the presentation type by itself."
+> **Domain expert:** "Into the **Admin Drink Write Workflow**. It owns the **Admin Drink Write Path** while the drinks **Service** stays router-agnostic."
 >
-> **Dev:** "How does that relate to **Editor**?"
+> **Dev:** "What happens when image parsing fails before we get to `routeAction(...)`?"
 >
-> **Domain expert:** "**Editor** is the form-side model for create/edit; **Drink view** is the read-side shape for the gallery. Same **Drink** domain, different jobs."
+> **Domain expert:** "That is a **Preparation Failure**. It should come back as validation-shaped errors, not as a thrown redirect or arbitrary response."
 
 ## Flagged ambiguities
 
@@ -84,3 +95,7 @@
 - "read service" / "write service" were used for TypeScript shapes. Prefer one **Service**; use **Mutation boundary** for external effects that only apply to mutations, not a second service name.
 - A dedicated "writer" **factory name** in `core` implied a second seam. Prefer one `createDrinksService` with **Mutation boundaries** supplied at mutating call sites (or a single module-local helper), not a second conceptual **Service**.
 - "**Published**" named a read-model type while an **Admin** can view an **Unpublished drink** in the same presentation shape. Prefer **Drink view** for the gallery presentation; reserve **Published drink** for visibility and for operations that only return published rows (e.g. public catalog listings, search).
+- "wiring" was too vague. Prefer **Workflow** for domain-specific application orchestration and **Framework Adapter** for framework-specific translation.
+- "response" was too broad in pre-`routeAction` discussion. Prefer **Preparation Failure** for validation-shaped early failures and reserve thrown responses for navigational control flow.
+- "save flow" was used loosely. Prefer **Admin Drink Write Path** for the end-to-end admin create/update/delete capability.
+- routes assembling schema, redirect, and toast policy ad hoc obscured ownership. Prefer a **Prepared Intent** built by the **Admin Drink Write Workflow** and executed through the **Route Action Seam**.

--- a/app/routes/admin.drinks.$slug.delete.tsx
+++ b/app/routes/admin.drinks.$slug.delete.tsx
@@ -1,9 +1,9 @@
 import { redirect, href } from "react-router";
-import { intent, routeAction } from "#/app/core/route-action.server";
+import { routeAction } from "#/app/core/route-action.server";
 import { getDb } from "#/app/db/client.server";
 import { purgeDrinkCache } from "#/app/integrations/fastly.server";
 import { deleteImage, uploadImage } from "#/app/integrations/imagekit.server";
-import { createDrinksService } from "#/app/modules/drinks/drinks.server";
+import { createAdminDrinkWriteWorkflow } from "#/app/workflows/admin-drink-write.server";
 import type { Route } from "./+types/admin.drinks.$slug.delete";
 
 export async function loader() {
@@ -11,23 +11,14 @@ export async function loader() {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const drinksService = createDrinksService({
+  const workflow = createAdminDrinkWriteWorkflow({
     db: getDb(),
-    writeEffects: {
-      uploadImage,
-      deleteImage,
-      purgeDrinkCache,
-    },
+    uploadImage,
+    deleteImage,
+    purgeDrinkCache,
   });
 
-  return routeAction(
-    request,
-    intent({
-      operation: async () => drinksService.deleteDrink({ slug: params.slug }),
-      redirectTo: href("/admin/drinks"),
-      toast: {
-        successMessage: "Drink deleted!",
-      },
-    }),
-  );
+  const deleteIntent = await workflow.prepareDelete({ slug: params.slug });
+
+  return routeAction(request, deleteIntent);
 }

--- a/app/routes/admin.drinks.$slug.edit.tsx
+++ b/app/routes/admin.drinks.$slug.edit.tsx
@@ -1,14 +1,12 @@
 import { data, href } from "react-router";
-import { DomainError } from "#/app/core/errors";
-import { parseImageUpload } from "#/app/core/image-upload.server";
-import { intent, routeAction } from "#/app/core/route-action.server";
+import { routeAction } from "#/app/core/route-action.server";
 import { getFormErrors } from "#/app/core/utils";
 import { getDb } from "#/app/db/client.server";
 import { purgeDrinkCache } from "#/app/integrations/fastly.server";
 import { deleteImage, uploadImage } from "#/app/integrations/imagekit.server";
-import { drinkDraftSchema, SaveDrinkNoticeCodes } from "#/app/modules/drinks/drinks";
 import { createDrinksService, DrinkEditorNotFoundError } from "#/app/modules/drinks/drinks.server";
 import { DrinkForm } from "#/app/ui/admin/drink-form";
+import { createAdminDrinkWriteWorkflow } from "#/app/workflows/admin-drink-write.server";
 import type { Route } from "./+types/admin.drinks.$slug.edit";
 
 export async function loader({ params }: Route.LoaderArgs) {
@@ -43,41 +41,27 @@ export default function EditDrinkPage({ loaderData, actionData }: Route.Componen
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const drinksService = createDrinksService({
+  const workflow = createAdminDrinkWriteWorkflow({
     db: getDb(),
-    writeEffects: {
-      uploadImage,
-      deleteImage,
-      purgeDrinkCache,
-    },
+    uploadImage,
+    deleteImage,
+    purgeDrinkCache,
   });
-  const { imageUpload, imageError } = await parseImageUpload(request.clone());
 
-  if (imageError) {
-    return data({ fieldErrors: {}, formErrors: [imageError] }, { status: 400 });
+  const preparation = await workflow.prepareUpdate({
+    request,
+    slug: params.slug,
+  });
+
+  if (preparation.kind === "invalid") {
+    return data(
+      {
+        fieldErrors: preparation.fieldErrors,
+        formErrors: preparation.formErrors,
+      },
+      { status: preparation.status },
+    );
   }
 
-  return routeAction(
-    request,
-    intent({
-      schema: drinkDraftSchema,
-      operation: async (draft) =>
-        drinksService.updateDrink({
-          slug: params.slug,
-          draft,
-          imageBuffer: imageUpload?.buffer,
-        }),
-      redirectTo: href("/admin/drinks"),
-      toast: (operationResult) => {
-        if (operationResult instanceof DomainError) {
-          return { kind: "error", message: operationResult.message };
-        }
-        return operationResult.notices.some(
-          (notice) => notice.code === SaveDrinkNoticeCodes.oldImageCleanupFailed,
-        )
-          ? { kind: "warning", message: "Drink updated, but old image cleanup failed" }
-          : { kind: "success", message: "Drink updated!" };
-      },
-    }),
-  );
+  return routeAction(request, preparation.intent);
 }

--- a/app/routes/admin.drinks.new.tsx
+++ b/app/routes/admin.drinks.new.tsx
@@ -1,13 +1,11 @@
 import { data, href } from "react-router";
-import { parseImageUpload } from "#/app/core/image-upload.server";
-import { intent, routeAction } from "#/app/core/route-action.server";
+import { routeAction } from "#/app/core/route-action.server";
 import { getFormErrors } from "#/app/core/utils";
 import { getDb } from "#/app/db/client.server";
 import { purgeDrinkCache } from "#/app/integrations/fastly.server";
 import { deleteImage, uploadImage } from "#/app/integrations/imagekit.server";
-import { drinkDraftSchema } from "#/app/modules/drinks/drinks";
-import { createDrinksService } from "#/app/modules/drinks/drinks.server";
 import { DrinkForm } from "#/app/ui/admin/drink-form";
+import { createAdminDrinkWriteWorkflow } from "#/app/workflows/admin-drink-write.server";
 import type { Route } from "./+types/admin.drinks.new";
 
 export default function NewDrinkPage({ actionData }: Route.ComponentProps) {
@@ -21,38 +19,24 @@ export default function NewDrinkPage({ actionData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { imageUpload, imageError } = await parseImageUpload(request.clone());
-
-  if (imageError) {
-    return data({ fieldErrors: {}, formErrors: [imageError] }, { status: 400 });
-  }
-
-  if (!imageUpload) {
-    return data({ fieldErrors: {}, formErrors: ["Image is required"] }, { status: 400 });
-  }
-
-  const drinksService = createDrinksService({
+  const workflow = createAdminDrinkWriteWorkflow({
     db: getDb(),
-    writeEffects: {
-      uploadImage,
-      deleteImage,
-      purgeDrinkCache,
-    },
+    uploadImage,
+    deleteImage,
+    purgeDrinkCache,
   });
 
-  return routeAction(
-    request,
-    intent({
-      schema: drinkDraftSchema,
-      operation: async (draft) =>
-        drinksService.createDrink({
-          draft,
-          imageBuffer: imageUpload.buffer,
-        }),
-      redirectTo: href("/admin/drinks"),
-      toast: {
-        successMessage: "Drink created!",
+  const preparation = await workflow.prepareCreate({ request });
+
+  if (preparation.kind === "invalid") {
+    return data(
+      {
+        fieldErrors: preparation.fieldErrors,
+        formErrors: preparation.formErrors,
       },
-    }),
-  );
+      { status: preparation.status },
+    );
+  }
+
+  return routeAction(request, preparation.intent);
 }

--- a/app/workflows/admin-drink-write.server.ts
+++ b/app/workflows/admin-drink-write.server.ts
@@ -1,0 +1,148 @@
+import { href } from "react-router";
+import { DomainError } from "#/app/core/errors";
+import { parseImageUpload } from "#/app/core/image-upload.server";
+import { intent, type Intent } from "#/app/core/route-action.server";
+import type { getDb } from "#/app/db/client.server";
+import { drinkDraftSchema, SaveDrinkNoticeCodes } from "#/app/modules/drinks/drinks";
+import { createDrinksService } from "#/app/modules/drinks/drinks.server";
+
+type Db = ReturnType<typeof getDb>;
+type UploadImage = (file: Buffer, fileName: string) => Promise<{ url: string; fileId: string }>;
+type DeleteImage = (fileId: string) => Promise<void>;
+type PurgeDrinkCache = (drink: { slug: string; tags: string[] }) => Promise<void>;
+type ImageUpload = NonNullable<Awaited<ReturnType<typeof parseImageUpload>>["imageUpload"]>;
+
+type DrinkWritePreparationInvalidResult = {
+  kind: "invalid";
+  fieldErrors: Record<string, string[] | undefined>;
+  formErrors: string[];
+  status: 400;
+};
+
+type DrinkWritePreparationReadyResult = {
+  kind: "ready";
+  intent: Intent;
+};
+
+export type DrinkWritePreparationResult =
+  | DrinkWritePreparationReadyResult
+  | DrinkWritePreparationInvalidResult;
+
+export type AdminDrinkWriteWorkflow = {
+  prepareCreate(input: { request: Request }): Promise<DrinkWritePreparationResult>;
+  prepareUpdate(input: { request: Request; slug: string }): Promise<DrinkWritePreparationResult>;
+  prepareDelete(input: { slug: string }): Promise<Intent>;
+};
+
+export function createAdminDrinkWriteWorkflow(deps: {
+  db: Db;
+  uploadImage: UploadImage;
+  deleteImage: DeleteImage;
+  purgeDrinkCache: PurgeDrinkCache;
+}): AdminDrinkWriteWorkflow {
+  const drinksService = createDrinksService({
+    db: deps.db,
+    writeEffects: {
+      uploadImage: deps.uploadImage,
+      deleteImage: deps.deleteImage,
+      purgeDrinkCache: deps.purgeDrinkCache,
+    },
+  });
+
+  return {
+    async prepareCreate({ request }) {
+      const imagePreparation = await prepareImageUpload(request);
+      if (imagePreparation.kind === "invalid") {
+        return imagePreparation;
+      }
+
+      const imageUpload = imagePreparation.imageUpload;
+      if (!imageUpload) {
+        return invalidPreparation("Image is required");
+      }
+
+      return {
+        kind: "ready",
+        intent: intent({
+          schema: drinkDraftSchema,
+          operation: async (draft) =>
+            drinksService.createDrink({
+              draft,
+              imageBuffer: imageUpload.buffer,
+            }),
+          redirectTo: href("/admin/drinks"),
+          toast: {
+            successMessage: "Drink created!",
+          },
+        }),
+      };
+    },
+    async prepareUpdate({ request, slug }) {
+      const imagePreparation = await prepareImageUpload(request);
+      if (imagePreparation.kind === "invalid") {
+        return imagePreparation;
+      }
+
+      return {
+        kind: "ready",
+        intent: intent({
+          schema: drinkDraftSchema,
+          operation: async (draft) =>
+            drinksService.updateDrink({
+              slug,
+              draft,
+              imageBuffer: imagePreparation.imageUpload?.buffer,
+            }),
+          redirectTo: href("/admin/drinks"),
+          toast: (operationResult) => {
+            if (operationResult instanceof DomainError) {
+              return { kind: "error", message: operationResult.message };
+            }
+            return operationResult.notices.some(
+              (notice) => notice.code === SaveDrinkNoticeCodes.oldImageCleanupFailed,
+            )
+              ? { kind: "warning", message: "Drink updated, but old image cleanup failed" }
+              : { kind: "success", message: "Drink updated!" };
+          },
+        }),
+      };
+    },
+    async prepareDelete({ slug }) {
+      return intent({
+        operation: async () => drinksService.deleteDrink({ slug }),
+        redirectTo: href("/admin/drinks"),
+        toast: {
+          successMessage: "Drink deleted!",
+        },
+      });
+    },
+  };
+}
+
+async function prepareImageUpload(
+  request: Request,
+): Promise<
+  { kind: "ready"; imageUpload: ImageUpload | undefined } | DrinkWritePreparationInvalidResult
+> {
+  const { imageUpload, imageError } = await parseImageUpload(request.clone());
+
+  if (imageError) {
+    return invalidPreparation(imageError);
+  }
+
+  return {
+    kind: "ready",
+    imageUpload,
+  };
+}
+
+function invalidPreparation(message: string): DrinkWritePreparationInvalidResult {
+  return {
+    kind: "invalid",
+    fieldErrors: {
+      imageFile: [message],
+    },
+    formErrors: [],
+    status: 400,
+  };
+}

--- a/app/workflows/admin-drink-write.test.ts
+++ b/app/workflows/admin-drink-write.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getToast } from "#/app/core/toast.server";
+import { routeAction } from "#/app/core/route-action.server";
+import { getDb } from "#/app/db/client.server";
+import { resetAndSeedDatabase } from "#/app/db/reset.server";
+import { createDrinksService } from "#/app/modules/drinks/drinks.server";
+import { createAdminDrinkWriteWorkflow } from "./admin-drink-write.server";
+
+function buildDrinkFormRequest(
+  overrides: {
+    imageFile?: File;
+    url?: string;
+  } = {},
+) {
+  const formData = new FormData();
+  formData.set("title", "Workflow Cocktail");
+  formData.set("slug", "workflow-cocktail");
+  formData.set("ingredients", "gin\ntonic");
+  formData.set("calories", "150");
+  formData.set("tags", "gin, refreshing");
+  formData.set("notes", "Built in workflow tests");
+  formData.set("rank", "0");
+  formData.set("status", "published");
+
+  if (overrides.imageFile) {
+    formData.set("imageFile", overrides.imageFile);
+  }
+
+  return new Request(overrides.url ?? "http://test.local/admin/drinks/new", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+function testWorkflow(
+  overrides: Partial<Parameters<typeof createAdminDrinkWriteWorkflow>[0]> = {},
+) {
+  return createAdminDrinkWriteWorkflow({
+    db: getDb(),
+    uploadImage: vi.fn().mockResolvedValue({
+      url: "https://ik.imagekit.io/test/drinks/workflow-cocktail.jpg",
+      fileId: "workflow-file-id",
+    }),
+    deleteImage: vi.fn().mockResolvedValue(undefined),
+    purgeDrinkCache: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  });
+}
+
+async function catchRedirect(fn: () => Promise<unknown>): Promise<Response> {
+  try {
+    await fn();
+    throw new Error("Expected a redirect Response to be thrown");
+  } catch (error) {
+    if (error instanceof Response) {
+      return error;
+    }
+
+    throw error;
+  }
+}
+
+beforeEach(async () => {
+  await resetAndSeedDatabase();
+});
+
+describe("createAdminDrinkWriteWorkflow", () => {
+  test("prepareCreate returns imageFile field errors when image is missing", async () => {
+    const workflow = testWorkflow();
+
+    const result = await workflow.prepareCreate({
+      request: buildDrinkFormRequest(),
+    });
+
+    expect(result).toEqual({
+      kind: "invalid",
+      fieldErrors: {
+        imageFile: ["Image is required"],
+      },
+      formErrors: [],
+      status: 400,
+    });
+  });
+
+  test("prepareUpdate is ready when no replacement image is uploaded", async () => {
+    const workflow = testWorkflow();
+
+    const result = await workflow.prepareUpdate({
+      request: buildDrinkFormRequest({
+        url: "http://test.local/admin/drinks/test-margarita/edit",
+      }),
+      slug: "test-margarita",
+    });
+
+    expect(result.kind).toBe("ready");
+  });
+
+  test("prepareCreate returns imageFile field errors for unsupported image types", async () => {
+    const workflow = testWorkflow();
+
+    const result = await workflow.prepareCreate({
+      request: buildDrinkFormRequest({
+        imageFile: new File(["not-an-image"], "bad.txt", { type: "text/plain" }),
+      }),
+    });
+
+    expect(result).toEqual({
+      kind: "invalid",
+      fieldErrors: {
+        imageFile: ["Image must be a JPEG, PNG, WebP, or GIF"],
+      },
+      formErrors: [],
+      status: 400,
+    });
+  });
+
+  test("prepareCreate returns a ready intent that routeAction can execute", async () => {
+    const workflow = testWorkflow();
+    const request = buildDrinkFormRequest({
+      imageFile: new File(["fake-image"], "workflow-cocktail.png", { type: "image/png" }),
+    });
+
+    const result = await workflow.prepareCreate({ request });
+
+    expect(result.kind).toBe("ready");
+    if (result.kind !== "ready") {
+      return;
+    }
+
+    const response = await catchRedirect(() => routeAction(request, result.intent));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/admin/drinks");
+
+    const { toast } = await getToast(
+      new Request("http://test.local/admin", {
+        headers: { Cookie: response.headers.get("Set-Cookie")! },
+      }),
+    );
+    expect(toast).toEqual({ kind: "success", message: "Drink created!" });
+
+    const drinksService = createDrinksService({ db: getDb() });
+    const editor = await drinksService.getDrinkEditorBySlug("workflow-cocktail");
+    expect(editor.initialValues.title).toBe("Workflow Cocktail");
+  });
+
+  test("prepareUpdate returns a warning toast when old image cleanup fails", async () => {
+    const workflow = testWorkflow({
+      uploadImage: vi.fn().mockResolvedValue({
+        url: "https://ik.imagekit.io/test/drinks/test-margarita.jpg",
+        fileId: "replacement-file-id",
+      }),
+      deleteImage: vi.fn().mockRejectedValue(new Error("cleanup failed")),
+    });
+    const request = buildDrinkFormRequest({
+      url: "http://test.local/admin/drinks/test-margarita/edit",
+      imageFile: new File(["replacement-image"], "test-margarita.png", { type: "image/png" }),
+    });
+
+    const result = await workflow.prepareUpdate({
+      request,
+      slug: "test-margarita",
+    });
+
+    expect(result.kind).toBe("ready");
+    if (result.kind !== "ready") {
+      return;
+    }
+
+    const response = await catchRedirect(() => routeAction(request, result.intent));
+
+    const { toast } = await getToast(
+      new Request("http://test.local/admin", {
+        headers: { Cookie: response.headers.get("Set-Cookie")! },
+      }),
+    );
+    expect(toast).toEqual({
+      kind: "warning",
+      message: "Drink updated, but old image cleanup failed",
+    });
+
+    const drinksService = createDrinksService({ db: getDb() });
+    const editor = await drinksService.getDrinkEditorBySlug("workflow-cocktail");
+    expect(editor.initialValues.title).toBe("Workflow Cocktail");
+  });
+
+  test("prepareDelete returns an intent that deletes the drink", async () => {
+    const workflow = testWorkflow();
+    const request = new Request("http://test.local/admin/drinks/test-margarita/delete", {
+      method: "POST",
+    });
+
+    const deleteIntent = await workflow.prepareDelete({ slug: "test-margarita" });
+    const response = await catchRedirect(() => routeAction(request, deleteIntent));
+
+    expect(response.headers.get("Location")).toBe("/admin/drinks");
+
+    const { toast } = await getToast(
+      new Request("http://test.local/admin", {
+        headers: { Cookie: response.headers.get("Set-Cookie")! },
+      }),
+    );
+    expect(toast).toEqual({ kind: "success", message: "Drink deleted!" });
+
+    await expect(
+      createDrinksService({ db: getDb() }).getDrinkEditorBySlug("test-margarita"),
+    ).rejects.toThrowError('Drink not found for slug "test-margarita"');
+  });
+});


### PR DESCRIPTION
## Why

The admin drink write path had become harder to follow than the business behavior itself. The create, edit, and delete routes were each reassembling the same upload parsing, drinks service construction, and `intent(...)` policy around redirects and toasts.

This refactor pulls that app-specific orchestration into a dedicated workflow while keeping `routeAction(...)` explicit in the routes. That preserves the existing architectural seam, reduces duplication, and gives the request-preparation behavior a focused place to live and be tested.

## Summary

- add an admin drink write workflow that prepares intents for create, update, and delete operations
- keep `routeAction(...)` explicit in admin write routes while removing duplicated upload and intent assembly logic
- add focused workflow tests using real request payloads and update the ubiquitous language for the new seam

## Testing

- `pnpm test -- --run app/workflows/admin-drink-write.test.ts app/modules/drinks/drinks.test.ts app/core/route-action.test.ts`
- `pnpm typecheck`
- `pnpm lint`

Closes #298
