### PR TITLE
Refine admin drink submission parser seam

### DIFF
--- a/app/routes/admin.drinks.new.tsx
+++ b/app/routes/admin.drinks.new.tsx
@@ -33,10 +33,6 @@ export async function action({ request }: Route.ActionArgs) {
     );
   }
 
-  if (!submission.imageUpload) {
-    throw new Error("Create drink submission parser returned ready without an image upload");
-  }
-
   const imageUpload = submission.imageUpload;
   const adminDrinksWriteService = createAdminDrinksWriteService({
     db: getDb(),

--- a/app/web/admin-drink-submission.server.ts
+++ b/app/web/admin-drink-submission.server.ts
@@ -23,9 +23,18 @@ type DrinkSubmissionReadyResult = {
   imageUpload: DrinkImageUpload | undefined;
 };
 
-export type DrinkSubmissionResult = DrinkSubmissionInvalidResult | DrinkSubmissionReadyResult;
+type CreateDrinkSubmissionReadyResult = Omit<DrinkSubmissionReadyResult, "imageUpload"> & {
+  imageUpload: DrinkImageUpload;
+};
 
-export async function parseCreateDrinkSubmission(request: Request): Promise<DrinkSubmissionResult> {
+export type DrinkSubmissionResult = DrinkSubmissionInvalidResult | DrinkSubmissionReadyResult;
+export type CreateDrinkSubmissionResult =
+  | DrinkSubmissionInvalidResult
+  | CreateDrinkSubmissionReadyResult;
+
+export async function parseCreateDrinkSubmission(
+  request: Request,
+): Promise<CreateDrinkSubmissionResult> {
   const result = await parseDrinkSubmission(request);
   if (result.kind === "invalid") {
     return result;
@@ -35,7 +44,10 @@ export async function parseCreateDrinkSubmission(request: Request): Promise<Drin
     return imageFieldError("Image is required");
   }
 
-  return result;
+  return {
+    ...result,
+    imageUpload: result.imageUpload,
+  };
 }
 
 export async function parseUpdateDrinkSubmission(request: Request): Promise<DrinkSubmissionResult> {

--- a/app/web/admin-drink-submission.server.ts
+++ b/app/web/admin-drink-submission.server.ts
@@ -1,5 +1,4 @@
 import { FormDataParseError, parseFormData, type FileUpload } from "@remix-run/form-data-parser";
-import { drinkDraftSchema, type DrinkDraft } from "#/app/modules/drinks/drinks";
 
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
@@ -18,7 +17,6 @@ type DrinkSubmissionInvalidResult = {
 
 type DrinkSubmissionReadyResult = {
   kind: "ready";
-  draft: DrinkDraft;
   formData: FormData;
   imageUpload: DrinkImageUpload | undefined;
 };
@@ -60,20 +58,8 @@ async function parseDrinkSubmission(request: Request): Promise<DrinkSubmissionRe
     return parsedMultipart;
   }
 
-  const draftResult = drinkDraftSchema.safeParse(Object.fromEntries(parsedMultipart.formData));
-  if (!draftResult.success) {
-    const flattenedError = draftResult.error.flatten();
-    return {
-      kind: "invalid",
-      fieldErrors: flattenedError.fieldErrors,
-      formErrors: flattenedError.formErrors,
-      status: 400,
-    };
-  }
-
   return {
     kind: "ready",
-    draft: draftResult.data,
     formData: parsedMultipart.formData,
     imageUpload: parsedMultipart.imageUpload,
   };

--- a/app/web/admin-drink-submission.test.ts
+++ b/app/web/admin-drink-submission.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
 import {
   parseCreateDrinkSubmission,
   parseUpdateDrinkSubmission,
@@ -111,6 +111,7 @@ describe("drink submission parsing", () => {
       status: "published",
     });
     expect(result.formData.get("title")).toBe("Parsed Cocktail");
+    expectTypeOf(result.imageUpload).toEqualTypeOf<{ buffer: Buffer; contentType: string }>();
     expect(result.imageUpload).toEqual({
       buffer: Buffer.from("fake-image"),
       contentType: "image/png",

--- a/app/web/admin-drink-submission.test.ts
+++ b/app/web/admin-drink-submission.test.ts
@@ -54,41 +54,53 @@ describe("drink submission parsing", () => {
     expect(result.draft.title).toBe("Parsed Cocktail");
   });
 
-  test("unsupported image types return an imageFile field error", async () => {
-    const result = await parseCreateDrinkSubmission(
-      buildDrinkFormRequest({
-        imageFile: new File(["not-an-image"], "bad.txt", { type: "text/plain" }),
-      }),
-    );
+  test.each([
+    ["create", parseCreateDrinkSubmission],
+    ["update", parseUpdateDrinkSubmission],
+  ])(
+    "%s submissions with unsupported image types return an imageFile field error",
+    async (_, parse) => {
+      const result = await parse(
+        buildDrinkFormRequest({
+          imageFile: new File(["not-an-image"], "bad.txt", { type: "text/plain" }),
+        }),
+      );
 
-    expect(result).toEqual({
-      kind: "invalid",
-      fieldErrors: {
-        imageFile: ["Image must be a JPEG, PNG, WebP, or GIF"],
-      },
-      formErrors: [],
-      status: 400,
-    });
-  });
+      expect(result).toEqual({
+        kind: "invalid",
+        fieldErrors: {
+          imageFile: ["Image must be a JPEG, PNG, WebP, or GIF"],
+        },
+        formErrors: [],
+        status: 400,
+      });
+    },
+  );
 
-  test("oversized image uploads return an imageFile field error", async () => {
-    const oversizedBytes = new Uint8Array(5 * 1024 * 1024 + 1);
+  test.each([
+    ["create", parseCreateDrinkSubmission],
+    ["update", parseUpdateDrinkSubmission],
+  ])(
+    "%s submissions with oversized image uploads return an imageFile field error",
+    async (_, parse) => {
+      const oversizedBytes = new Uint8Array(5 * 1024 * 1024 + 1);
 
-    const result = await parseCreateDrinkSubmission(
-      buildDrinkFormRequest({
-        imageFile: new File([oversizedBytes], "large.png", { type: "image/png" }),
-      }),
-    );
+      const result = await parse(
+        buildDrinkFormRequest({
+          imageFile: new File([oversizedBytes], "large.png", { type: "image/png" }),
+        }),
+      );
 
-    expect(result).toEqual({
-      kind: "invalid",
-      fieldErrors: {
-        imageFile: ["Image must be under 5MB"],
-      },
-      formErrors: [],
-      status: 400,
-    });
-  });
+      expect(result).toEqual({
+        kind: "invalid",
+        fieldErrors: {
+          imageFile: ["Image must be under 5MB"],
+        },
+        formErrors: [],
+        status: 400,
+      });
+    },
+  );
 
   test("valid submissions return normalized draft data and image upload data", async () => {
     const result = await parseCreateDrinkSubmission(

--- a/app/web/admin-drink-submission.test.ts
+++ b/app/web/admin-drink-submission.test.ts
@@ -4,20 +4,13 @@ import {
   parseUpdateDrinkSubmission,
 } from "./admin-drink-submission.server";
 
-function buildDrinkFormRequest(
+function buildMultipartRequest(
   overrides: {
     imageFile?: File;
   } = {},
 ) {
   const formData = new FormData();
-  formData.set("title", "Parsed Cocktail");
-  formData.set("slug", "parsed-cocktail");
-  formData.set("ingredients", "gin\ntonic");
-  formData.set("calories", "150");
-  formData.set("tags", "gin, refreshing");
-  formData.set("notes", "Built in parser tests");
-  formData.set("rank", "0");
-  formData.set("status", "published");
+  formData.set("caption", "Multipart parser payload");
 
   if (overrides.imageFile) {
     formData.set("imageFile", overrides.imageFile);
@@ -31,7 +24,7 @@ function buildDrinkFormRequest(
 
 describe("drink submission parsing", () => {
   test("create submissions require an image", async () => {
-    const result = await parseCreateDrinkSubmission(buildDrinkFormRequest());
+    const result = await parseCreateDrinkSubmission(buildMultipartRequest());
 
     expect(result).toEqual({
       kind: "invalid",
@@ -44,14 +37,14 @@ describe("drink submission parsing", () => {
   });
 
   test("update submissions allow keeping the current image", async () => {
-    const result = await parseUpdateDrinkSubmission(buildDrinkFormRequest());
+    const result = await parseUpdateDrinkSubmission(buildMultipartRequest());
 
     expect(result.kind).toBe("ready");
     if (result.kind !== "ready") {
       return;
     }
     expect(result.imageUpload).toBeUndefined();
-    expect(result.formData.get("title")).toBe("Parsed Cocktail");
+    expect(result.formData.get("caption")).toBe("Multipart parser payload");
   });
 
   test.each([
@@ -61,7 +54,7 @@ describe("drink submission parsing", () => {
     "%s submissions with unsupported image types return an imageFile field error",
     async (_, parse) => {
       const result = await parse(
-        buildDrinkFormRequest({
+        buildMultipartRequest({
           imageFile: new File(["not-an-image"], "bad.txt", { type: "text/plain" }),
         }),
       );
@@ -86,7 +79,7 @@ describe("drink submission parsing", () => {
       const oversizedBytes = new Uint8Array(5 * 1024 * 1024 + 1);
 
       const result = await parse(
-        buildDrinkFormRequest({
+        buildMultipartRequest({
           imageFile: new File([oversizedBytes], "large.png", { type: "image/png" }),
         }),
       );
@@ -102,23 +95,18 @@ describe("drink submission parsing", () => {
     },
   );
 
-  test("valid submissions return form data and image upload data without validating drink draft fields", async () => {
-    const request = buildDrinkFormRequest({
-      imageFile: new File(["fake-image"], "parsed-cocktail.png", { type: "image/png" }),
-    });
-    const formData = await request.formData();
-    formData.set("calories", "not a number");
-
+  test("valid create submissions return form data and image upload data", async () => {
     const result = await parseCreateDrinkSubmission(
-      new Request(request.url, { method: "POST", body: formData }),
+      buildMultipartRequest({
+        imageFile: new File(["fake-image"], "parsed-cocktail.png", { type: "image/png" }),
+      }),
     );
 
     expect(result.kind).toBe("ready");
     if (result.kind !== "ready") {
       return;
     }
-    expect(result.formData.get("title")).toBe("Parsed Cocktail");
-    expect(result.formData.get("calories")).toBe("not a number");
+    expect(result.formData.get("caption")).toBe("Multipart parser payload");
     expectTypeOf(result.imageUpload).toEqualTypeOf<{ buffer: Buffer; contentType: string }>();
     expect(result.imageUpload).toEqual({
       buffer: Buffer.from("fake-image"),

--- a/app/web/admin-drink-submission.test.ts
+++ b/app/web/admin-drink-submission.test.ts
@@ -51,7 +51,7 @@ describe("drink submission parsing", () => {
       return;
     }
     expect(result.imageUpload).toBeUndefined();
-    expect(result.draft.title).toBe("Parsed Cocktail");
+    expect(result.formData.get("title")).toBe("Parsed Cocktail");
   });
 
   test.each([
@@ -102,27 +102,23 @@ describe("drink submission parsing", () => {
     },
   );
 
-  test("valid submissions return normalized draft data and image upload data", async () => {
+  test("valid submissions return form data and image upload data without validating drink draft fields", async () => {
+    const request = buildDrinkFormRequest({
+      imageFile: new File(["fake-image"], "parsed-cocktail.png", { type: "image/png" }),
+    });
+    const formData = await request.formData();
+    formData.set("calories", "not a number");
+
     const result = await parseCreateDrinkSubmission(
-      buildDrinkFormRequest({
-        imageFile: new File(["fake-image"], "parsed-cocktail.png", { type: "image/png" }),
-      }),
+      new Request(request.url, { method: "POST", body: formData }),
     );
 
     expect(result.kind).toBe("ready");
     if (result.kind !== "ready") {
       return;
     }
-    expect(result.draft).toMatchObject({
-      title: "Parsed Cocktail",
-      slug: "parsed-cocktail",
-      ingredients: ["gin", "tonic"],
-      calories: 150,
-      tags: ["gin", "refreshing"],
-      rank: 0,
-      status: "published",
-    });
     expect(result.formData.get("title")).toBe("Parsed Cocktail");
+    expect(result.formData.get("calories")).toBe("not a number");
     expectTypeOf(result.imageUpload).toEqualTypeOf<{ buffer: Buffer; contentType: string }>();
     expect(result.imageUpload).toEqual({
       buffer: Buffer.from("fake-image"),

--- a/docs/adr/0001-admin-drink-write-route-adapters.md
+++ b/docs/adr/0001-admin-drink-write-route-adapters.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+---
+
+# Keep React Router adapters for Admin Drink Write Path outcomes
+
+The **Admin Drink Write Path** keeps a transport-agnostic Drinks module seam: `createAdminDrinksWriteService` returns typed write outcomes, while React Router route actions adapt those outcomes into framework responses, field/form errors, redirects, and toasts. We accept this seam because pushing React Router response concerns behind the Drinks module would reduce the module's transport independence.
+
+## Consequences
+
+- Route actions may translate typed **Admin Drink Write Path** outcomes into React Router responses when that translation is route/framework-specific.
+- The Drinks module owns Drink write behavior, image lifecycle orchestration, cache purge orchestration, and typed write outcomes.
+- Repeated business behavior in route actions should move behind the Drinks module seam; framework-specific adaptation may stay in routes.


### PR DESCRIPTION
## Summary

- keep admin drink submission parsing focused on multipart image upload concerns
- move drink draft validation back to the route action pipeline via preserved `FormData`
- make ready create submissions guarantee an image upload and remove the impossible route-level guard
- refocus parser tests on create/update image upload behavior and ready result shape

Closes #312
Closes #313
Closes #314
Closes #315
Closes #316

## Validation

- Not run (not requested)
