### PR TITLE
refactor: remove legacy drinks write service interface

### DIFF
--- a/app/core/route-action.server.ts
+++ b/app/core/route-action.server.ts
@@ -51,7 +51,7 @@ export type Intent = IntentDef & { [INTENT_BRAND]: true };
  * @example
  * const createDrinkIntent = intent({
  *   schema: drinkDraftSchema,
- *   operation: (draft) => drinksService.createDrink({
+ *   operation: (draft) => adminDrinksWriteService.create({
  *     draft,
  *     imageBuffer,
  *   }),
@@ -61,7 +61,7 @@ export type Intent = IntentDef & { [INTENT_BRAND]: true };
  *
  * @example
  * const deleteDrinkIntent = intent({
- *   operation: () => drinksService.deleteDrink({ slug: params.slug }),
+ *   operation: () => adminDrinksWriteService.delete({ slug: params.slug }),
  *   redirectTo: href("/admin/drinks"),
  *   toast: { successMessage: "Drink deleted!" },
  * });
@@ -131,12 +131,12 @@ function isBrandedIntent(value: unknown): value is Intent {
  * return routeAction(request, {
  *   update: intent({
  *     schema: drinkDraftSchema,
- *     operation: (draft) => drinksService.updateDrink({ slug: params.slug, draft }),
+ *     operation: (draft) => adminDrinksWriteService.update({ slug: params.slug, draft }),
  *     redirectTo: href("/admin/drinks"),
  *     toast: { successMessage: "Drink updated!" },
  *   }),
  *   delete: intent({
- *     operation: () => drinksService.deleteDrink({ slug: params.slug }),
+ *     operation: () => adminDrinksWriteService.delete({ slug: params.slug }),
  *     redirectTo: href("/admin/drinks"),
  *     toast: { successMessage: "Drink deleted!" },
  *   }),

--- a/app/modules/drinks/drinks.server.ts
+++ b/app/modules/drinks/drinks.server.ts
@@ -17,8 +17,6 @@ import {
   type DeleteAdminDrinkResult,
   type DrinkDraft,
   type DrinksService,
-  type DrinksServiceMutationKey,
-  type DrinksServiceWithoutMutations,
   type SaveDrinkNotice,
   type UpdateAdminDrinkCommand,
   type UpdateAdminDrinkResult,
@@ -44,19 +42,8 @@ export class DrinkEditorNotFoundError extends Error {
   }
 }
 
-export function createDrinksService(deps: { db: Db }): DrinksServiceWithoutMutations;
-export function createDrinksService(deps: {
-  db: Db;
-  writeEffects: DrinksWriteEffects;
-}): DrinksService;
-export function createDrinksService(
-  deps: { db: Db } | { db: Db; writeEffects: DrinksWriteEffects },
-): DrinksServiceWithoutMutations | DrinksService {
-  const read = buildDrinksServiceReadMethods({ db: deps.db });
-  if (!("writeEffects" in deps)) {
-    return read;
-  }
-  return { ...read, ...buildDrinksServiceMutationMethods(deps.db, deps.writeEffects) };
+export function createDrinksService(deps: { db: Db }): DrinksService {
+  return buildDrinksServiceReadMethods({ db: deps.db });
 }
 
 export function createAdminDrinksWriteService(deps: {
@@ -76,7 +63,7 @@ export function createAdminDrinksWriteService(deps: {
   };
 }
 
-function buildDrinksServiceReadMethods(deps: { db: Db }): DrinksServiceWithoutMutations {
+function buildDrinksServiceReadMethods(deps: { db: Db }): DrinksService {
   return {
     async getPublishedDrinks() {
       const publishedDrinks = await deps.db.query.drinks.findMany({
@@ -192,41 +179,6 @@ function buildDrinksServiceReadMethods(deps: { db: Db }): DrinksServiceWithoutMu
           status: drink.status,
         },
       };
-    },
-  };
-}
-
-function buildDrinksServiceMutationMethods(
-  db: Db,
-  writeEffects: DrinksWriteEffects,
-): Pick<DrinksService, DrinksServiceMutationKey> {
-  return {
-    async createDrink(command) {
-      return createAdminDrink(db, writeEffects, command);
-    },
-    async updateDrink(command) {
-      const result = await updateAdminDrink(db, writeEffects, command);
-
-      if (result.kind === "notFound") {
-        throw new Error(`Drink not found for slug "${result.slug}"`);
-      }
-
-      if (result.kind === "fieldError") {
-        const [field, messages] = Object.entries(result.fieldErrors)[0] ?? [];
-        throw new FieldDomainError(field ?? "slug", messages?.[0] ?? "Invalid drink");
-      }
-
-      return {
-        drinkSlug: result.drinkSlug,
-        notices: result.notices,
-      };
-    },
-    async deleteDrink({ slug }) {
-      const result = await deleteAdminDrink(db, writeEffects, { slug });
-
-      if (result.kind === "notFound") {
-        throw new Error(`Drink not found for slug "${result.slug}"`);
-      }
     },
   };
 }

--- a/app/modules/drinks/drinks.test.ts
+++ b/app/modules/drinks/drinks.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import { getDb } from "#/app/db/client.server";
-import { FieldDomainError } from "#/app/core/errors";
 import { drinks } from "#/app/db/schema";
 import { resetAndSeedDatabase } from "#/app/db/reset.server";
 import { drinkDraftSchema, SaveDrinkNoticeCodes } from "./drinks";
@@ -14,19 +13,18 @@ import {
 
 type TestDrinksServiceOverrides = {
   db?: ReturnType<typeof getDb>;
-  writeEffects?: Partial<NonNullable<Parameters<typeof createDrinksService>[0]["writeEffects"]>>;
+  writeEffects?: Partial<Parameters<typeof createAdminDrinksWriteService>[0]["writeEffects"]>;
 };
 
-function testDrinksService(overrides: TestDrinksServiceOverrides = {}) {
+function testAdminDrinksWriteService(overrides: TestDrinksServiceOverrides = {}) {
   const defaultWriteEffects = {
     uploadImage: vi.fn(),
     deleteImage: vi.fn(),
     purgeDrinkCache: vi.fn(),
   };
 
-  return createDrinksService({
+  return createAdminDrinksWriteService({
     db: overrides.db ?? getDb(),
-    ...overrides,
     writeEffects: {
       ...defaultWriteEffects,
       ...overrides.writeEffects,
@@ -47,7 +45,7 @@ async function setDrinkStatus(slug: string, status: "published" | "unpublished")
 describe("createDrinksService", () => {
   test("returns published drinks for read-only and default test services", async () => {
     const readOnlyService = createDrinksService({ db: getDb() });
-    const defaultService = testDrinksService();
+    const defaultService = createDrinksService({ db: getDb() });
 
     const fromReadOnly = await readOnlyService.getPublishedDrinks();
     const fromDefault = await defaultService.getPublishedDrinks();
@@ -69,7 +67,7 @@ describe("createDrinksService", () => {
   });
 
   test("loads a new-drink editor with form-shaped defaults", async () => {
-    const service = testDrinksService();
+    const service = createDrinksService({ db: getDb() });
 
     const editor = await service.getNewDrinkEditor();
 
@@ -89,7 +87,7 @@ describe("createDrinksService", () => {
   });
 
   test("returns a drink for viewer when a published drink is requested", async () => {
-    const service = testDrinksService();
+    const service = createDrinksService({ db: getDb() });
 
     const drinkForViewer = await service.getDrinkBySlug({
       slug: "test-margarita",
@@ -112,7 +110,7 @@ describe("createDrinksService", () => {
 
   test("hides an unpublished drink from non-admin viewers", async () => {
     await setDrinkStatus("test-margarita", "unpublished");
-    const service = testDrinksService();
+    const service = createDrinksService({ db: getDb() });
 
     const drinkForViewer = await service.getDrinkBySlug({
       slug: "test-margarita",
@@ -124,7 +122,7 @@ describe("createDrinksService", () => {
 
   test("returns an unpublished drink to admin viewers with private visibility", async () => {
     await setDrinkStatus("test-margarita", "unpublished");
-    const service = testDrinksService();
+    const service = createDrinksService({ db: getDb() });
 
     const drinkForViewer = await service.getDrinkBySlug({
       slug: "test-margarita",
@@ -141,7 +139,7 @@ describe("createDrinksService", () => {
   });
 
   test("returns published drinks for a case-insensitive tag", async () => {
-    const service = testDrinksService();
+    const service = createDrinksService({ db: getDb() });
 
     const taggedDrinks = await service.getDrinksByTag("Citrus");
 
@@ -150,7 +148,7 @@ describe("createDrinksService", () => {
 
   test("returns all published tags as a direct list", async () => {
     await setDrinkStatus("test-old-fashioned", "unpublished");
-    const service = testDrinksService();
+    const service = createDrinksService({ db: getDb() });
 
     const tags = await service.getAllTags();
 
@@ -158,7 +156,7 @@ describe("createDrinksService", () => {
   });
 
   test("returns published search results as a direct list", async () => {
-    const service = testDrinksService();
+    const service = createDrinksService({ db: getDb() });
 
     const searchResults = await service.searchPublishedDrinks({ query: "tequila" });
 
@@ -170,7 +168,7 @@ describe("createDrinksService", () => {
   });
 
   test("returns an empty search result list when query is blank", async () => {
-    const service = testDrinksService();
+    const service = createDrinksService({ db: getDb() });
 
     const emptySearchResults = await service.searchPublishedDrinks({ query: "" });
 
@@ -178,7 +176,7 @@ describe("createDrinksService", () => {
   });
 
   test("returns all drinks for admin list views as a direct list", async () => {
-    const service = testDrinksService();
+    const service = createDrinksService({ db: getDb() });
 
     const allDrinks = await service.getAllDrinks();
 
@@ -194,21 +192,23 @@ describe("createDrinksService", () => {
       rank: 10,
     });
   });
+});
 
+describe("createAdminDrinksWriteService", () => {
   test("creates a drink and exposes it through the editor boundary", async () => {
     const uploadImage = vi.fn().mockResolvedValue({
       url: "https://ik.imagekit.io/test/drinks/test-cocktail.jpg",
       fileId: "new-file-id",
     });
     const purgeDrinkCache = vi.fn().mockResolvedValue(undefined);
-    const service = testDrinksService({
+    const service = testAdminDrinksWriteService({
       writeEffects: {
         uploadImage,
         purgeDrinkCache,
       },
     });
 
-    const result = await service.createDrink({
+    const result = await service.create({
       draft: {
         title: "Test Cocktail",
         slug: "test-cocktail",
@@ -232,7 +232,7 @@ describe("createDrinksService", () => {
       tags: ["gin", "refreshing"],
     });
 
-    const editor = await service.getDrinkEditorBySlug("test-cocktail");
+    const editor = await createDrinksService({ db: getDb() }).getDrinkEditorBySlug("test-cocktail");
 
     expect(editor).toEqual({
       mode: "edit",
@@ -419,8 +419,8 @@ describe("createDrinksService", () => {
     expect(purgeDrinkCache).not.toHaveBeenCalled();
   });
 
-  test("throws a typed slug error when creating with a duplicate slug", async () => {
-    const service = testDrinksService({
+  test("returns typed slug error when creating with a duplicate slug", async () => {
+    const service = testAdminDrinksWriteService({
       writeEffects: {
         uploadImage: vi.fn().mockResolvedValue({
           url: "https://ik.imagekit.io/test/drinks/test-margarita.jpg",
@@ -430,7 +430,7 @@ describe("createDrinksService", () => {
     });
 
     await expect(
-      service.createDrink({
+      service.create({
         draft: {
           title: "Duplicate Margarita",
           slug: "test-margarita",
@@ -443,7 +443,7 @@ describe("createDrinksService", () => {
         },
         imageBuffer: Buffer.from("fake-image"),
       }),
-    ).rejects.toEqual(new FieldDomainError("slug", "Slug already exists"));
+    ).rejects.toMatchObject({ field: "slug", message: "Slug already exists" });
   });
 
   test("updates an existing drink without replacing its image", async () => {
@@ -451,7 +451,7 @@ describe("createDrinksService", () => {
     const deleteImage = vi.fn();
     const purgeDrinkCache = vi.fn().mockResolvedValue(undefined);
 
-    const service = testDrinksService({
+    const service = testAdminDrinksWriteService({
       writeEffects: {
         uploadImage,
         deleteImage,
@@ -459,7 +459,7 @@ describe("createDrinksService", () => {
       },
     });
 
-    const result = await service.updateDrink({
+    const result = await service.update({
       slug: "test-margarita",
       draft: {
         title: "Updated Margarita",
@@ -474,6 +474,7 @@ describe("createDrinksService", () => {
     });
 
     expect(result).toEqual({
+      kind: "success",
       drinkSlug: "test-margarita",
       notices: [],
     });
@@ -485,7 +486,9 @@ describe("createDrinksService", () => {
       tags: ["tequila", "citrus", "updated"],
     });
 
-    const editor = await service.getDrinkEditorBySlug("test-margarita");
+    const editor = await createDrinksService({ db: getDb() }).getDrinkEditorBySlug(
+      "test-margarita",
+    );
 
     expect(editor).toEqual({
       mode: "edit",
@@ -507,13 +510,13 @@ describe("createDrinksService", () => {
 
   test("invalidates both old and new detail pages when a drink slug changes", async () => {
     const purgeDrinkCache = vi.fn().mockResolvedValue(undefined);
-    const service = testDrinksService({
+    const service = testAdminDrinksWriteService({
       writeEffects: {
         purgeDrinkCache,
       },
     });
 
-    await service.updateDrink({
+    await service.update({
       slug: "test-margarita",
       draft: {
         title: "Renamed Margarita",
@@ -534,7 +537,7 @@ describe("createDrinksService", () => {
   });
 
   test("returns warning metadata when old image cleanup fails after a successful update", async () => {
-    const service = testDrinksService({
+    const service = testAdminDrinksWriteService({
       writeEffects: {
         uploadImage: vi.fn().mockResolvedValue({
           url: "https://ik.imagekit.io/test/drinks/test-margarita.jpg",
@@ -545,7 +548,7 @@ describe("createDrinksService", () => {
       },
     });
 
-    const result = await service.updateDrink({
+    const result = await service.update({
       slug: "test-margarita",
       draft: {
         title: "Test Margarita",
@@ -561,29 +564,32 @@ describe("createDrinksService", () => {
     });
 
     expect(result).toEqual({
+      kind: "success",
       drinkSlug: "test-margarita",
       notices: [{ code: SaveDrinkNoticeCodes.oldImageCleanupFailed, message: "cleanup failed" }],
     });
 
-    const editor = await service.getDrinkEditorBySlug("test-margarita");
+    const editor = await createDrinksService({ db: getDb() }).getDrinkEditorBySlug(
+      "test-margarita",
+    );
     expect(editor.initialValues.title).toBe("Test Margarita");
   });
 
-  test("deletes a drink through the service boundary", async () => {
+  test("deletes a drink through the admin write boundary", async () => {
     const deleteImage = vi.fn().mockResolvedValue(undefined);
     const purgeDrinkCache = vi.fn().mockResolvedValue(undefined);
-    const service = testDrinksService({
+    const service = testAdminDrinksWriteService({
       writeEffects: {
         deleteImage,
         purgeDrinkCache,
       },
     });
 
-    await service.deleteDrink({ slug: "test-margarita" });
+    await service.delete({ slug: "test-margarita" });
 
-    await expect(service.getDrinkEditorBySlug("test-margarita")).rejects.toThrowError(
-      DrinkEditorNotFoundError,
-    );
+    await expect(
+      createDrinksService({ db: getDb() }).getDrinkEditorBySlug("test-margarita"),
+    ).rejects.toThrowError(DrinkEditorNotFoundError);
     expect(deleteImage).toHaveBeenCalledWith("seed-fileId-1");
     expect(purgeDrinkCache).toHaveBeenCalledWith({
       slugs: ["test-margarita"],

--- a/app/modules/drinks/drinks.ts
+++ b/app/modules/drinks/drinks.ts
@@ -73,11 +73,6 @@ export type AdminDrinkListItem = {
   updatedAt: Date;
 };
 
-export const drinksServiceMutationKeys = ["createDrink", "updateDrink", "deleteDrink"] as const;
-
-export type DrinksServiceMutationKey = (typeof drinksServiceMutationKeys)[number];
-
-/** One drinks module service; mutations omitted when the factory is built without `writeEffects`. */
 export type CreateAdminDrinkCommand = {
   draft: DrinkDraft;
   imageBuffer: Buffer;
@@ -134,13 +129,4 @@ export interface DrinksService {
   searchPublishedDrinks(input: { query: string }): Promise<DrinkView[]>;
   getNewDrinkEditor(): Promise<DrinkEditor>;
   getDrinkEditorBySlug(slug: string): Promise<DrinkEditor>;
-  createDrink(input: { draft: DrinkDraft; imageBuffer: Buffer }): Promise<SaveDrinkResult>;
-  updateDrink(input: {
-    slug: string;
-    draft: DrinkDraft;
-    imageBuffer?: Buffer;
-  }): Promise<SaveDrinkResult>;
-  deleteDrink(input: { slug: string }): Promise<void>;
 }
-
-export type DrinksServiceWithoutMutations = Omit<DrinksService, DrinksServiceMutationKey>;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,13 +32,10 @@ Routes stay thin. They create a service per request and delegate business behavi
 Example shape:
 
 ```ts
-const drinksService = createDrinksService({
+const drinksService = createDrinksService({ db: getDb() });
+const adminDrinksWriteService = createAdminDrinksWriteService({
   db: getDb(),
-  writeEffects: {
-    uploadImage,
-    deleteImage,
-    purgeDrinkCache,
-  },
+  writeEffects: { uploadImage, deleteImage, purgeDrinkCache },
 });
 ```
 
@@ -72,9 +69,9 @@ Current `Drinks` seam examples:
 - `searchPublishedDrinks({ query })`
 - `getNewDrinkEditor()`
 - `getDrinkEditorBySlug(slug)`
-- `createDrink({ draft, imageBuffer })`
-- `updateDrink({ slug, draft, imageBuffer? })`
-- `deleteDrink({ slug })`
+- `createAdminDrinksWriteService(...).create({ draft, imageBuffer })`
+- `createAdminDrinksWriteService(...).update({ slug, draft, imageBuffer? })`
+- `createAdminDrinksWriteService(...).delete({ slug })`
 
 ## Identity Module
 
@@ -119,6 +116,7 @@ Preferred boundary tests:
 
 - `drinkDraftSchema`
 - `createDrinksService(...)`
+- `createAdminDrinksWriteService(...)`
 - `createIdentityService(...)`
 - `routeAction(...)`
 


### PR DESCRIPTION
## Summary

- removes the legacy `createDrinksService({ db, writeEffects })` overload and read-service mutation methods
- keeps `createAdminDrinksWriteService` as the single public Admin Drink Write Path seam
- moves write-path tests to the admin write service boundary while keeping read behavior tests on `createDrinksService({ db })`
- updates architecture and route-action examples to teach the current read/write seams

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm vitest run app/modules/drinks/drinks.test.ts`

Closes #318
