### PR TITLE
Refine drink tag canonicalization

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,8 +23,16 @@ A **Drink** whose visibility state restricts viewing to an **Admin**.
 _Avoid_: draft drink, hidden drink
 
 **Tag**:
-A label attached to a **Drink** for grouping and discovery.
+A label attached to a **Drink** for grouping and discovery. A **Tag** is canonically stored as a lowercase phrase derived from its URL slug. Equivalent **Tags** that share the same URL slug collapse to one **Tag**.
 _Avoid_: category, facet, label
+
+**Tag display name**:
+The lowercase phrase shown to viewers for a **Tag**.
+_Avoid_: label, title
+
+**Tag slug**:
+The URL-safe identity for a **Tag**. The **Tag display name** is derived from the **Tag slug**.
+_Avoid_: tag id, route param
 
 **Drink for viewer**:
 A **Drink view** paired with the visibility outcome for a specific viewer.

--- a/app/core/utils.ts
+++ b/app/core/utils.ts
@@ -15,10 +15,6 @@ export function getLoaderDataForHandle<TLoaderData = unknown>(
   return match.loaderData as TLoaderData;
 }
 
-export function getSurrogateKeyForTag(tag: string) {
-  return tag.replaceAll(" ", "_");
-}
-
 // TODO: remove once requestIdleCallback is available in Safari
 // https://caniuse.com/requestidlecallback
 export function requestIdleCallbackShim(cb: () => void) {

--- a/app/integrations/fastly.server.ts
+++ b/app/integrations/fastly.server.ts
@@ -1,5 +1,12 @@
 import { getEnvVars } from "#/app/core/env.server";
-import { getSurrogateKeyForTag } from "#/app/core/utils";
+
+export function getSurrogateKeyForTagSlug(tagSlug: string) {
+  return tagSlug;
+}
+
+function getSurrogateKeyForCanonicalTag(tag: string) {
+  return tag.replaceAll(" ", "_");
+}
 
 async function purgeFastlyCache(surrogateKeys: string[]): Promise<void> {
   const { FASTLY_SERVICE_ID, FASTLY_PURGE_API_KEY } = getEnvVars();
@@ -34,7 +41,7 @@ export async function purgeDrinkCache(affectedPages: {
     "search",
     ...affectedPages.slugs,
     "tags",
-    ...affectedPages.tags.map(getSurrogateKeyForTag),
+    ...affectedPages.tags.map(getSurrogateKeyForCanonicalTag),
   ];
   await purgeFastlyCache(keys);
 }

--- a/app/modules/drinks/drinks-images.server.ts
+++ b/app/modules/drinks/drinks-images.server.ts
@@ -1,7 +1,7 @@
-import { kebabCase } from "lodash-es";
 import { transformUrl } from "unpic";
 import type { Drink } from "#/app/db/schema";
-import type { DrinkTagView, DrinkView } from "./drinks";
+import type { DrinkView } from "./drinks";
+import { toDrinkTagViews } from "./drinks-tags.server";
 
 // Transparent 1x1 pixel GIF as fallback when blur placeholder generation fails
 const FALLBACK_BLUR_DATA_URL =
@@ -40,30 +40,6 @@ async function generateBlurDataUrl(imageUrl: string): Promise<string> {
     // Fetch failed, use fallback
     return FALLBACK_BLUR_DATA_URL;
   }
-}
-
-function toDrinkTagView(tag: string): DrinkTagView | null {
-  const slug = kebabCase(tag);
-
-  if (!slug) {
-    return null;
-  }
-
-  return { displayName: slug.replaceAll("-", " "), slug };
-}
-
-function toDrinkTagViews(tags: string[]): DrinkTagView[] {
-  const tagViewsBySlug = new Map<string, DrinkTagView>();
-
-  for (const tag of tags) {
-    const tagView = toDrinkTagView(tag);
-
-    if (tagView && !tagViewsBySlug.has(tagView.slug)) {
-      tagViewsBySlug.set(tagView.slug, tagView);
-    }
-  }
-
-  return Array.from(tagViewsBySlug.values());
 }
 
 export async function withPlaceholderImages(drinks: Drink[]): Promise<DrinkView[]> {

--- a/app/modules/drinks/drinks-images.server.ts
+++ b/app/modules/drinks/drinks-images.server.ts
@@ -1,6 +1,7 @@
+import { kebabCase } from "lodash-es";
 import { transformUrl } from "unpic";
 import type { Drink } from "#/app/db/schema";
-import type { DrinkView } from "./drinks";
+import type { DrinkTagView, DrinkView } from "./drinks";
 
 // Transparent 1x1 pixel GIF as fallback when blur placeholder generation fails
 const FALLBACK_BLUR_DATA_URL =
@@ -41,6 +42,30 @@ async function generateBlurDataUrl(imageUrl: string): Promise<string> {
   }
 }
 
+function toDrinkTagView(tag: string): DrinkTagView | null {
+  const slug = kebabCase(tag);
+
+  if (!slug) {
+    return null;
+  }
+
+  return { displayName: slug.replaceAll("-", " "), slug };
+}
+
+function toDrinkTagViews(tags: string[]): DrinkTagView[] {
+  const tagViewsBySlug = new Map<string, DrinkTagView>();
+
+  for (const tag of tags) {
+    const tagView = toDrinkTagView(tag);
+
+    if (tagView && !tagViewsBySlug.has(tagView.slug)) {
+      tagViewsBySlug.set(tagView.slug, tagView);
+    }
+  }
+
+  return Array.from(tagViewsBySlug.values());
+}
+
 export async function withPlaceholderImages(drinks: Drink[]): Promise<DrinkView[]> {
   return Promise.all(
     drinks.map(async (drink) => {
@@ -53,7 +78,7 @@ export async function withPlaceholderImages(drinks: Drink[]): Promise<DrinkView[
         ingredients: drink.ingredients,
         calories: drink.calories,
         notes: drink.notes,
-        tags: drink.tags,
+        tags: toDrinkTagViews(drink.tags),
       };
     }),
   );

--- a/app/modules/drinks/drinks-schemas.ts
+++ b/app/modules/drinks/drinks-schemas.ts
@@ -1,3 +1,4 @@
+import { kebabCase } from "lodash-es";
 import { z } from "zod";
 
 export const drinkStatusValues = ["published", "unpublished"] as const;
@@ -20,6 +21,22 @@ const commaSeparatedList = z.string().transform((value) =>
     .filter(Boolean),
 );
 
+const canonicalTagList = commaSeparatedList.transform((tags) => {
+  const canonicalTagsBySlug = new Map<string, string>();
+
+  for (const tag of tags) {
+    const tagSlug = kebabCase(tag);
+
+    if (!tagSlug || canonicalTagsBySlug.has(tagSlug)) {
+      continue;
+    }
+
+    canonicalTagsBySlug.set(tagSlug, tagSlug.replaceAll("-", " "));
+  }
+
+  return Array.from(canonicalTagsBySlug.values());
+});
+
 const intFromString = z.string().transform((value) => Number.parseInt(value, 10));
 
 export const drinkDraftSchema = z.object({
@@ -36,7 +53,7 @@ export const drinkDraftSchema = z.object({
   calories: intFromString.pipe(
     z.int("Calories must be a whole number").min(0, "Calories cannot be negative"),
   ),
-  tags: commaSeparatedList.pipe(z.array(z.string()).min(1, "At least one tag is required")),
+  tags: canonicalTagList.pipe(z.array(z.string()).min(1, "At least one tag is required")),
   notes: trimmedString.transform((value) => value || null),
   rank: intFromString.pipe(z.int("Rank must be a whole number")),
   status: z.enum(drinkStatusValues),

--- a/app/modules/drinks/drinks-tags.server.ts
+++ b/app/modules/drinks/drinks-tags.server.ts
@@ -1,0 +1,18 @@
+import { kebabCase } from "lodash-es";
+import type { DrinkTagView } from "./drinks";
+
+export function toDrinkTagViews(tags: string[]): DrinkTagView[] {
+  const tagViewsBySlug = new Map<string, DrinkTagView>();
+
+  for (const tag of tags) {
+    const slug = kebabCase(tag);
+
+    if (!slug || tagViewsBySlug.has(slug)) {
+      continue;
+    }
+
+    tagViewsBySlug.set(slug, { displayName: slug.replaceAll("-", " "), slug });
+  }
+
+  return Array.from(tagViewsBySlug.values());
+}

--- a/app/modules/drinks/drinks.server.ts
+++ b/app/modules/drinks/drinks.server.ts
@@ -7,6 +7,7 @@ import { drinks, type Drink } from "#/app/db/schema";
 import { markdownToHtml } from "./drinks-markdown.server";
 import { withPlaceholderImages } from "./drinks-images.server";
 import { purgeSearchCache, searchDrinks } from "./drinks-search.server";
+import { toDrinkTagViews } from "./drinks-tags.server";
 
 export { purgeSearchCache };
 import {
@@ -94,7 +95,9 @@ function buildDrinksServiceReadMethods(deps: { db: Db }): DrinksService {
         where: eq(drinks.status, "published"),
         columns: { tags: true },
       });
-      return Array.from(new Set(publishedTags.flatMap((drink) => drink.tags))).sort();
+      return toDrinkTagViews(publishedTags.flatMap((drink) => drink.tags)).sort((left, right) =>
+        left.displayName.localeCompare(right.displayName),
+      );
     },
     async getDrinkBySlug({ slug, viewerRole }) {
       const drink = await deps.db.query.drinks.findFirst({

--- a/app/modules/drinks/drinks.server.ts
+++ b/app/modules/drinks/drinks.server.ts
@@ -1,6 +1,5 @@
 import { createId } from "@paralleldrive/cuid2";
 import { desc, eq } from "drizzle-orm";
-import { lowerCase } from "lodash-es";
 import { FieldDomainError } from "#/app/core/errors";
 import type { getDb } from "#/app/db/client.server";
 import { drinks, type Drink } from "#/app/db/schema";
@@ -18,6 +17,7 @@ import {
   type DeleteAdminDrinkResult,
   type DrinkDraft,
   type DrinksService,
+  type DrinkTagView,
   type SaveDrinkNotice,
   type UpdateAdminDrinkCommand,
   type UpdateAdminDrinkResult,
@@ -125,15 +125,32 @@ function buildDrinksServiceReadMethods(deps: { db: Db }): DrinksService {
         },
       };
     },
-    async getDrinksByTag(tag) {
-      const normalizedTag = lowerCase(tag);
+    async getDrinksByTagSlug({ tagSlug }) {
       const publishedDrinks = await deps.db.query.drinks.findMany({
         where: eq(drinks.status, "published"),
         orderBy: [desc(drinks.rank), desc(drinks.createdAt)],
       });
-      const matchingDrinks = publishedDrinks.filter((drink) => drink.tags.includes(normalizedTag));
 
-      return matchingDrinks.length === 0 ? null : withPlaceholderImages(matchingDrinks);
+      let resolvedTag: DrinkTagView | null = null;
+      const matchingDrinks = publishedDrinks.filter((drink) => {
+        const matchingTag = toDrinkTagViews(drink.tags).find((tag) => tag.slug === tagSlug);
+
+        if (!matchingTag) {
+          return false;
+        }
+
+        resolvedTag ??= matchingTag;
+        return true;
+      });
+
+      if (!resolvedTag || matchingDrinks.length === 0) {
+        return null;
+      }
+
+      return {
+        tag: resolvedTag,
+        drinks: await withPlaceholderImages(matchingDrinks),
+      };
     },
     async searchPublishedDrinks({ query }) {
       if (!query) {

--- a/app/modules/drinks/drinks.test.ts
+++ b/app/modules/drinks/drinks.test.ts
@@ -208,17 +208,19 @@ describe("createAdminDrinksWriteService", () => {
       },
     });
 
+    const draft = drinkDraftSchema.parse({
+      title: "Test Cocktail",
+      slug: "test-cocktail",
+      ingredients: "gin\ntonic",
+      calories: "150",
+      tags: " Gin, refreshing, gin!, REFRESHING ",
+      notes: "",
+      rank: "0",
+      status: "published",
+    });
+
     const result = await service.create({
-      draft: {
-        title: "Test Cocktail",
-        slug: "test-cocktail",
-        ingredients: ["gin", "tonic"],
-        calories: 150,
-        tags: ["gin", "refreshing"],
-        notes: null,
-        rank: 0,
-        status: "published",
-      },
+      draft,
       imageBuffer: Buffer.from("fake-image"),
     });
 
@@ -459,18 +461,20 @@ describe("createAdminDrinksWriteService", () => {
       },
     });
 
+    const draft = drinkDraftSchema.parse({
+      title: "Updated Margarita",
+      slug: "test-margarita",
+      ingredients: "3 oz tequila\n1.5 oz lime juice",
+      calories: "250",
+      tags: "Tequila, updated, tequila!, UPDATED",
+      notes: "Updated notes",
+      rank: "5",
+      status: "published",
+    });
+
     const result = await service.update({
       slug: "test-margarita",
-      draft: {
-        title: "Updated Margarita",
-        slug: "test-margarita",
-        ingredients: ["3 oz tequila", "1.5 oz lime juice"],
-        calories: 250,
-        tags: ["tequila", "updated"],
-        notes: "Updated notes",
-        rank: 5,
-        status: "published",
-      },
+      draft,
     });
 
     expect(result).toEqual({

--- a/app/modules/drinks/drinks.test.ts
+++ b/app/modules/drinks/drinks.test.ts
@@ -173,13 +173,38 @@ describe("createDrinksService", () => {
     ]);
   });
 
-  test("returns all published tags as a direct list", async () => {
+  test("returns all published tags as link-ready tag views", async () => {
     await setDrinkStatus("test-old-fashioned", "unpublished");
     const service = createDrinksService({ db: getDb() });
 
     const tags = await service.getAllTags();
 
-    expect(tags).toEqual(["citrus", "mint", "rum", "tequila"]);
+    expect(tags).toEqual([
+      { displayName: "citrus", slug: "citrus" },
+      { displayName: "mint", slug: "mint" },
+      { displayName: "rum", slug: "rum" },
+      { displayName: "tequila", slug: "tequila" },
+    ]);
+  });
+
+  test("defensively canonicalizes and de-duplicates all published tags", async () => {
+    const db = getDb();
+    await db
+      .update(drinks)
+      .set({ tags: ["Tequila!", "bright citrus", "bright-citrus", " "] })
+      .where(eq(drinks.slug, "test-margarita"));
+    await setDrinkStatus("test-old-fashioned", "unpublished");
+    const service = createDrinksService({ db });
+
+    const tags = await service.getAllTags();
+
+    expect(tags).toEqual([
+      { displayName: "bright citrus", slug: "bright-citrus" },
+      { displayName: "citrus", slug: "citrus" },
+      { displayName: "mint", slug: "mint" },
+      { displayName: "rum", slug: "rum" },
+      { displayName: "tequila", slug: "tequila" },
+    ]);
   });
 
   test("defensively canonicalizes stored tags when returning drink views", async () => {

--- a/app/modules/drinks/drinks.test.ts
+++ b/app/modules/drinks/drinks.test.ts
@@ -144,19 +144,23 @@ describe("createDrinksService", () => {
     expect(drinkForViewer?.drink.notes).toContain("<p>A classic test margarita</p>");
   });
 
-  test("returns published drinks for a case-insensitive tag", async () => {
+  test("returns the resolved tag and published drinks for a tag slug", async () => {
     const service = createDrinksService({ db: getDb() });
 
-    const taggedDrinks = await service.getDrinksByTag("Citrus");
+    const taggedDrinks = await service.getDrinksByTagSlug({ tagSlug: "citrus" });
 
-    expect(taggedDrinks?.map((drink) => drink.slug)).toEqual(["test-margarita", "test-mojito"]);
-    expect(taggedDrinks?.[0]?.tags).toEqual([
+    expect(taggedDrinks?.tag).toEqual({ displayName: "citrus", slug: "citrus" });
+    expect(taggedDrinks?.drinks.map((drink) => drink.slug)).toEqual([
+      "test-margarita",
+      "test-mojito",
+    ]);
+    expect(taggedDrinks?.drinks[0]?.tags).toEqual([
       { displayName: "tequila", slug: "tequila" },
       { displayName: "citrus", slug: "citrus" },
     ]);
   });
 
-  test("returns published drinks for a tag slug", async () => {
+  test("returns published drinks for a multi-word tag slug", async () => {
     const db = getDb();
     await db
       .update(drinks)
@@ -164,12 +168,34 @@ describe("createDrinksService", () => {
       .where(eq(drinks.slug, "test-margarita"));
     const service = createDrinksService({ db });
 
-    const taggedDrinks = await service.getDrinksByTag("bright-citrus");
+    const taggedDrinks = await service.getDrinksByTagSlug({ tagSlug: "bright-citrus" });
 
-    expect(taggedDrinks?.map((drink) => drink.slug)).toEqual(["test-margarita"]);
-    expect(taggedDrinks?.[0]?.tags).toEqual([
+    expect(taggedDrinks?.tag).toEqual({ displayName: "bright citrus", slug: "bright-citrus" });
+    expect(taggedDrinks?.drinks.map((drink) => drink.slug)).toEqual(["test-margarita"]);
+    expect(taggedDrinks?.drinks[0]?.tags).toEqual([
       { displayName: "tequila", slug: "tequila" },
       { displayName: "bright citrus", slug: "bright-citrus" },
+    ]);
+  });
+
+  test("resolves equivalent stored tags to one tag page", async () => {
+    const db = getDb();
+    await db
+      .update(drinks)
+      .set({ tags: ["Bright Citrus"] })
+      .where(eq(drinks.slug, "test-margarita"));
+    await db
+      .update(drinks)
+      .set({ tags: ["bright-citrus"] })
+      .where(eq(drinks.slug, "test-mojito"));
+    const service = createDrinksService({ db });
+
+    const taggedDrinks = await service.getDrinksByTagSlug({ tagSlug: "bright-citrus" });
+
+    expect(taggedDrinks?.tag).toEqual({ displayName: "bright citrus", slug: "bright-citrus" });
+    expect(taggedDrinks?.drinks.map((drink) => drink.slug)).toEqual([
+      "test-margarita",
+      "test-mojito",
     ]);
   });
 

--- a/app/modules/drinks/drinks.test.ts
+++ b/app/modules/drinks/drinks.test.ts
@@ -58,7 +58,10 @@ describe("createDrinksService", () => {
       title: "Test Margarita",
       calories: 200,
       notes: "A classic test margarita",
-      tags: ["tequila", "citrus"],
+      tags: [
+        { displayName: "tequila", slug: "tequila" },
+        { displayName: "citrus", slug: "citrus" },
+      ],
     });
     expect(fromDefault[0]?.image).toEqual({
       url: expect.any(String),
@@ -99,7 +102,10 @@ describe("createDrinksService", () => {
       title: "Test Margarita",
       slug: "test-margarita",
       calories: 200,
-      tags: ["tequila", "citrus"],
+      tags: [
+        { displayName: "tequila", slug: "tequila" },
+        { displayName: "citrus", slug: "citrus" },
+      ],
     });
     expect(drinkForViewer?.drink.image).toEqual({
       url: expect.any(String),
@@ -144,6 +150,27 @@ describe("createDrinksService", () => {
     const taggedDrinks = await service.getDrinksByTag("Citrus");
 
     expect(taggedDrinks?.map((drink) => drink.slug)).toEqual(["test-margarita", "test-mojito"]);
+    expect(taggedDrinks?.[0]?.tags).toEqual([
+      { displayName: "tequila", slug: "tequila" },
+      { displayName: "citrus", slug: "citrus" },
+    ]);
+  });
+
+  test("returns published drinks for a tag slug", async () => {
+    const db = getDb();
+    await db
+      .update(drinks)
+      .set({ tags: ["tequila", "bright citrus"] })
+      .where(eq(drinks.slug, "test-margarita"));
+    const service = createDrinksService({ db });
+
+    const taggedDrinks = await service.getDrinksByTag("bright-citrus");
+
+    expect(taggedDrinks?.map((drink) => drink.slug)).toEqual(["test-margarita"]);
+    expect(taggedDrinks?.[0]?.tags).toEqual([
+      { displayName: "tequila", slug: "tequila" },
+      { displayName: "bright citrus", slug: "bright-citrus" },
+    ]);
   });
 
   test("returns all published tags as a direct list", async () => {
@@ -153,6 +180,25 @@ describe("createDrinksService", () => {
     const tags = await service.getAllTags();
 
     expect(tags).toEqual(["citrus", "mint", "rum", "tequila"]);
+  });
+
+  test("defensively canonicalizes stored tags when returning drink views", async () => {
+    const db = getDb();
+    await db
+      .update(drinks)
+      .set({ tags: ["Tequila!", "bright citrus", "bright-citrus", " "] })
+      .where(eq(drinks.slug, "test-margarita"));
+    const service = createDrinksService({ db });
+
+    const drinkForViewer = await service.getDrinkBySlug({
+      slug: "test-margarita",
+      viewerRole: "user",
+    });
+
+    expect(drinkForViewer?.drink.tags).toEqual([
+      { displayName: "tequila", slug: "tequila" },
+      { displayName: "bright citrus", slug: "bright-citrus" },
+    ]);
   });
 
   test("returns published search results as a direct list", async () => {
@@ -165,6 +211,10 @@ describe("createDrinksService", () => {
       url: expect.any(String),
       blurDataUrl: expect.any(String),
     });
+    expect(searchResults[0]?.tags).toEqual([
+      { displayName: "tequila", slug: "tequila" },
+      { displayName: "citrus", slug: "citrus" },
+    ]);
   });
 
   test("returns an empty search result list when query is blank", async () => {

--- a/app/modules/drinks/drinks.ts
+++ b/app/modules/drinks/drinks.ts
@@ -125,11 +125,16 @@ export interface AdminDrinksWriteService {
   delete(command: DeleteAdminDrinkCommand): Promise<DeleteAdminDrinkResult>;
 }
 
+export type DrinksByTagSlug = {
+  tag: DrinkTagView;
+  drinks: DrinkView[];
+};
+
 export interface DrinksService {
   getPublishedDrinks(): Promise<DrinkView[]>;
   getAllDrinks(): Promise<AdminDrinkListItem[]>;
   getDrinkBySlug(input: { slug: string; viewerRole: ViewerRole }): Promise<DrinkForViewer | null>;
-  getDrinksByTag(tag: string): Promise<DrinkView[] | null>;
+  getDrinksByTagSlug(input: { tagSlug: string }): Promise<DrinksByTagSlug | null>;
   getAllTags(): Promise<DrinkTagView[]>;
   searchPublishedDrinks(input: { query: string }): Promise<DrinkView[]>;
   getNewDrinkEditor(): Promise<DrinkEditor>;

--- a/app/modules/drinks/drinks.ts
+++ b/app/modules/drinks/drinks.ts
@@ -8,6 +8,11 @@ export type DrinkStatus = (typeof drinkStatusValues)[number];
  * Used for published-only lists/search/tags and for slug detail — including
  * unpublished rows when {@link DrinkForViewer.visibility} is `"private"`.
  */
+export type DrinkTagView = {
+  displayName: string;
+  slug: string;
+};
+
 export type DrinkView = {
   title: string;
   slug: string;
@@ -15,7 +20,7 @@ export type DrinkView = {
   ingredients: string[];
   calories: number;
   notes: string | null;
-  tags: string[];
+  tags: DrinkTagView[];
 };
 
 export { drinkDraftSchema, drinkStatusValues };

--- a/app/modules/drinks/drinks.ts
+++ b/app/modules/drinks/drinks.ts
@@ -130,7 +130,7 @@ export interface DrinksService {
   getAllDrinks(): Promise<AdminDrinkListItem[]>;
   getDrinkBySlug(input: { slug: string; viewerRole: ViewerRole }): Promise<DrinkForViewer | null>;
   getDrinksByTag(tag: string): Promise<DrinkView[] | null>;
-  getAllTags(): Promise<string[]>;
+  getAllTags(): Promise<DrinkTagView[]>;
   searchPublishedDrinks(input: { query: string }): Promise<DrinkView[]>;
   getNewDrinkEditor(): Promise<DrinkEditor>;
   getDrinkEditorBySlug(slug: string): Promise<DrinkEditor>;

--- a/app/routes/_app.tags.$tag.test.ts
+++ b/app/routes/_app.tags.$tag.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { resetAndSeedDatabase } from "#/app/db/reset.server";
-import { loader } from "./_app.tags.$tag";
+import { loader, meta } from "./_app.tags.$tag";
 
 beforeEach(async () => {
   await resetAndSeedDatabase();
@@ -14,13 +14,27 @@ describe("tag route", () => {
 
     const headers = getHeaders(response);
     const payload = getPayload(response) as {
+      tag: { displayName: string; slug: string };
       drinks: { slug: string }[];
     };
 
+    expect(payload.tag).toEqual({ displayName: "citrus", slug: "citrus" });
     expect(payload.drinks.map((drink) => drink.slug)).toEqual(["test-margarita", "test-mojito"]);
     expect(headers.get("Surrogate-Key")).toBe("all tags citrus");
     expect(headers.get("Cache-Control")).toContain("public");
     expect(headers.get("Cache-Control")).toContain("s-maxage=31557600");
+  });
+
+  test("uses the resolved tag display name for metadata", async () => {
+    const response = await loader({
+      params: { tag: "citrus" },
+    } as never);
+    const loaderData = getPayload(response);
+
+    const tags = meta({ loaderData, params: { tag: "citrus" } } as never);
+
+    expect(tags).toContainEqual({ title: "Drinks with citrus" });
+    expect(tags).toContainEqual({ name: "description", content: "All drinks containing citrus" });
   });
 });
 

--- a/app/routes/_app.tags.$tag.tsx
+++ b/app/routes/_app.tags.$tag.tsx
@@ -1,5 +1,5 @@
 import { data } from "react-router";
-import { lowerCase, startCase } from "lodash-es";
+import { lowerCase } from "lodash-es";
 import { cacheHeader } from "pretty-cache-header";
 import { invariantResponse } from "@epic-web/invariant";
 import { defaultPageDescription, defaultPageTitle } from "#/app/core/config";
@@ -18,9 +18,9 @@ export function headers({ loaderHeaders }: Route.HeadersArgs) {
 export async function loader({ params }: Route.LoaderArgs) {
   const { SITE_IMAGE_URL, SITE_IMAGE_ALT } = getEnvVars();
   const drinksService = createDrinksService({ db: getDb() });
-  const drinks = await drinksService.getDrinksByTag(params.tag);
+  const taggedDrinks = await drinksService.getDrinksByTagSlug({ tagSlug: params.tag });
 
-  invariantResponse(drinks, "No drinks found", {
+  invariantResponse(taggedDrinks, "No drinks found", {
     status: 404,
     headers: {
       "Surrogate-Key": "all",
@@ -35,7 +35,8 @@ export async function loader({ params }: Route.LoaderArgs) {
 
   return data(
     {
-      drinks,
+      tag: taggedDrinks.tag,
+      drinks: taggedDrinks.drinks,
       socialImageUrl: SITE_IMAGE_URL,
       socialImageAlt: SITE_IMAGE_ALT,
     },
@@ -63,7 +64,7 @@ export const handle: AppRouteHandle = {
     return {
       title: loaderData ? (
         <div className="inline-flex gap-2">
-          <span>{lowerCase(matches.at(-1)?.params.tag)}</span>
+          <span>{loaderData.tag.displayName}</span>
           <span>( {loaderData.drinks.length} )</span>
         </div>
       ) : (
@@ -75,11 +76,11 @@ export const handle: AppRouteHandle = {
 
 export function meta({ loaderData, params }: Route.MetaArgs) {
   const { socialImageUrl, socialImageAlt } = loaderData ?? {};
-  const { tag } = params;
+  const displayName = loaderData?.tag.displayName ?? lowerCase(params.tag);
 
   return [
-    { title: `Drinks with ${startCase(tag)}` },
-    { name: "description", content: `All drinks containing ${lowerCase(tag)}` },
+    { title: `Drinks with ${displayName}` },
+    { name: "description", content: `All drinks containing ${displayName}` },
     { property: "og:title", content: defaultPageTitle },
     { property: "og:description", content: defaultPageDescription },
     { property: "og:image", content: socialImageUrl },

--- a/app/routes/_app.tags.$tag.tsx
+++ b/app/routes/_app.tags.$tag.tsx
@@ -3,8 +3,9 @@ import { lowerCase } from "lodash-es";
 import { cacheHeader } from "pretty-cache-header";
 import { invariantResponse } from "@epic-web/invariant";
 import { defaultPageDescription, defaultPageTitle } from "#/app/core/config";
-import { getLoaderDataForHandle, getSurrogateKeyForTag } from "#/app/core/utils";
+import { getLoaderDataForHandle } from "#/app/core/utils";
 import { getEnvVars } from "#/app/core/env.server";
+import { getSurrogateKeyForTagSlug } from "#/app/integrations/fastly.server";
 import { getDb } from "#/app/db/client.server";
 import { createDrinksService } from "#/app/modules/drinks/drinks.server";
 import { DrinkList } from "#/app/ui/drinks/drink-list";
@@ -42,7 +43,7 @@ export async function loader({ params }: Route.LoaderArgs) {
     },
     {
       headers: {
-        "Surrogate-Key": `all tags ${getSurrogateKeyForTag(params.tag)}`,
+        "Surrogate-Key": `all tags ${getSurrogateKeyForTagSlug(taggedDrinks.tag.slug)}`,
         "Cache-Control": cacheHeader({
           public: true,
           maxAge: "30sec",

--- a/app/routes/_app.tags._index.test.tsx
+++ b/app/routes/_app.tags._index.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, test } from "vitest";
+import { resetAndSeedDatabase } from "#/app/db/reset.server";
+import TagsPage, { loader } from "./_app.tags._index";
+
+beforeEach(async () => {
+  await resetAndSeedDatabase();
+});
+
+describe("tags index route", () => {
+  test("returns link-ready tags with long-lived public cache headers", async () => {
+    const response = await loader();
+
+    const headers = getHeaders(response);
+    const payload = getPayload(response) as {
+      tags: { displayName: string; slug: string }[];
+    };
+
+    expect(payload.tags).toEqual([
+      { displayName: "bourbon", slug: "bourbon" },
+      { displayName: "citrus", slug: "citrus" },
+      { displayName: "classic", slug: "classic" },
+      { displayName: "mint", slug: "mint" },
+      { displayName: "rum", slug: "rum" },
+      { displayName: "tequila", slug: "tequila" },
+    ]);
+    expect(headers.get("Surrogate-Key")).toBe("all tags bourbon citrus classic mint rum tequila");
+    expect(headers.get("Cache-Control")).toContain("public");
+    expect(headers.get("Cache-Control")).toContain("s-maxage=31557600");
+  });
+
+  test("renders tag display names and links with tag slugs from loader data", () => {
+    const loaderData = {
+      tags: [{ displayName: "bright citrus", slug: "citrus" }],
+      socialImageUrl: "https://example.com/social.jpg",
+      socialImageAlt: "social image",
+    };
+
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        {/* @ts-expect-error Route props include framework metadata that this component does not use. */}
+        <TagsPage loaderData={loaderData} />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("bright citrus");
+    expect(markup).toContain('href="/tags/citrus"');
+  });
+});
+
+function getHeaders(response: unknown) {
+  if (response instanceof Response) {
+    return response.headers;
+  }
+
+  const init = (response as { init?: ResponseInit }).init;
+  return new Headers(init?.headers);
+}
+
+function getPayload(response: unknown) {
+  if (response instanceof Response) {
+    throw new Error("Expected react-router data payload, got Response");
+  }
+
+  return (response as { data: unknown }).data;
+}

--- a/app/routes/_app.tags._index.tsx
+++ b/app/routes/_app.tags._index.tsx
@@ -1,8 +1,8 @@
 import { data, href } from "react-router";
 import { cacheHeader } from "pretty-cache-header";
 import { defaultPageDescription, defaultPageTitle } from "#/app/core/config";
-import { getSurrogateKeyForTag } from "#/app/core/utils";
 import { getEnvVars } from "#/app/core/env.server";
+import { getSurrogateKeyForTagSlug } from "#/app/integrations/fastly.server";
 import { getDb } from "#/app/db/client.server";
 import { createDrinksService } from "#/app/modules/drinks/drinks.server";
 import { TagLink } from "#/app/ui/tags/tag-link";
@@ -17,7 +17,7 @@ export async function loader() {
   const { SITE_IMAGE_URL, SITE_IMAGE_ALT } = getEnvVars();
   const drinksService = createDrinksService({ db: getDb() });
   const tags = await drinksService.getAllTags();
-  const everyTagSurrogateKey = tags.map((tag) => getSurrogateKeyForTag(tag.slug)).join(" ");
+  const everyTagSurrogateKey = tags.map((tag) => getSurrogateKeyForTagSlug(tag.slug)).join(" ");
 
   return data(
     {

--- a/app/routes/_app.tags._index.tsx
+++ b/app/routes/_app.tags._index.tsx
@@ -1,5 +1,4 @@
 import { data, href } from "react-router";
-import { kebabCase } from "lodash-es";
 import { cacheHeader } from "pretty-cache-header";
 import { defaultPageDescription, defaultPageTitle } from "#/app/core/config";
 import { getSurrogateKeyForTag } from "#/app/core/utils";
@@ -18,7 +17,7 @@ export async function loader() {
   const { SITE_IMAGE_URL, SITE_IMAGE_ALT } = getEnvVars();
   const drinksService = createDrinksService({ db: getDb() });
   const tags = await drinksService.getAllTags();
-  const everyTagSurrogateKey = tags.map(getSurrogateKeyForTag).join(" ");
+  const everyTagSurrogateKey = tags.map((tag) => getSurrogateKeyForTag(tag.slug)).join(" ");
 
   return data(
     {
@@ -67,8 +66,8 @@ export default function TagsPage({ loaderData }: Route.ComponentProps) {
       className="mx-4 grid gap-4 sm:mx-0 sm:gap-8 lg:grid-cols-2 xl:grid-cols-3"
     >
       {tags.map((tag) => (
-        <TagLink to={href("/tags/:tag", { tag: kebabCase(tag) })} key={tag}>
-          <Tag className="p-4 text-2xl lg:p-6 lg:text-4xl">{tag}</Tag>
+        <TagLink to={href("/tags/:tag", { tag: tag.slug })} key={tag.slug}>
+          <Tag className="p-4 text-2xl lg:p-6 lg:text-4xl">{tag.displayName}</Tag>
         </TagLink>
       ))}
     </div>

--- a/app/ui/drinks/drink-details.test.tsx
+++ b/app/ui/drinks/drink-details.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { describe, expect, test } from "vitest";
+import type { DrinkView } from "#/app/modules/drinks/drinks";
+import { DrinkDetails } from "./drink-details";
+
+describe("DrinkDetails", () => {
+  test("renders tag display names and links with tag slugs from the drink view", () => {
+    const drink: DrinkView = {
+      title: "Tagged Drink",
+      slug: "tagged-drink",
+      image: { url: "https://example.com/drink.jpg", blurDataUrl: "data:image/gif;base64,test" },
+      ingredients: ["gin"],
+      calories: 100,
+      notes: null,
+      tags: [{ displayName: "bright citrus", slug: "citrus" }],
+    };
+
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <DrinkDetails drink={drink} />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("bright citrus");
+    expect(markup).toContain('href="/tags/citrus"');
+    expect(markup).toContain('aria-label="Find all drinks containing bright citrus"');
+  });
+});

--- a/app/ui/drinks/drink-details.tsx
+++ b/app/ui/drinks/drink-details.tsx
@@ -1,4 +1,3 @@
-import { kebabCase } from "lodash-es";
 import { href } from "react-router";
 import type { DrinkView } from "#/app/modules/drinks/drinks";
 import { Tag } from "#/app/ui/tags/tag";
@@ -20,12 +19,12 @@ export function DrinkDetails({ drink }: { drink: DrinkView }) {
           {drink.tags.map((tag) => (
             <TagLink
               className="mt-4 mr-4 ml-0 leading-tight lg:mr-0 lg:ml-4"
-              aria-label={`Find all drinks containing ${tag}`}
-              to={href("/tags/:tag", { tag: kebabCase(tag) })}
-              key={tag}
+              aria-label={`Find all drinks containing ${tag.displayName}`}
+              to={href("/tags/:tag", { tag: tag.slug })}
+              key={tag.slug}
             >
               <Tag className="p-2 text-sm leading-tight font-normal lg:text-base lg:leading-tight lg:font-light">
-                {tag}
+                {tag.displayName}
               </Tag>
             </TagLink>
           ))}


### PR DESCRIPTION
## Summary
- canonicalize drink tags into link-ready labels and slugs across admin, detail, and tag index flows
- resolve tag pages through the drinks module by slug and keep cache key derivation local to tags
- add coverage for tag normalization, tag index links, drink details links, and slug-backed tag pages

## Validation
- Not run (PR-only request)

Closes #321
Closes #322
Closes #323
Closes #324
Closes #325
Closes #326
