### PR TITLE
refactor: add admin drink write route adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ _Craft Cocktail Gallery_
 
 ## Skill Flow
 
-- Preferred workflow: `grill-me -> ubiquitous-language -> write-a-prd -> prd-to-issues -> tdd -> improve-codebase-architecture`
+- Preferred workflow: `domain-model -> to-prd -> to-issues -> tdd`
 
 ## React Compiler
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,10 @@ _Avoid_: redirect target, callback path
 The editorial operation that creates, updates, or deletes a **Drink**.
 _Avoid_: save flow, admin mutation layer
 
+**Admin Drink Write Route Adapter**:
+The web adapter that prepares route submissions for the **Admin Drink Write Path** and translates write outcomes into field errors, not-found responses, redirects, and toasts.
+_Avoid_: admin mutation handler, route plumbing
+
 ## Relationships
 
 - A **Drink** can have zero or more **Tags**
@@ -76,6 +80,7 @@ _Avoid_: save flow, admin mutation layer
 - An **Admin** is a kind of **User**
 - Only an **Admin** may view an **Unpublished drink**
 - Only an **Admin** can use the **Admin Drink Write Path**
+- The **Admin Drink Write Route Adapter** adapts route submissions to the **Admin Drink Write Path** but does not own **Drink** write behavior
 - A **Return-to URL** lets a **User** resume the page they attempted before authentication
 
 ## Example dialogue
@@ -94,3 +99,4 @@ _Avoid_: save flow, admin mutation layer
 - "published" was used for both visibility state and presentation shape — resolved: use **Published drink** for visibility and **Drink view** for presentation.
 - "account" was used to mean the authenticated person — resolved: use **User**.
 - "save flow" was used loosely — resolved: use **Admin Drink Write Path** for the admin create, update, and delete operation.
+- "route plumbing" was used for the web translation around admin writes — resolved: use **Admin Drink Write Route Adapter**.

--- a/app/modules/drinks/drinks.server.ts
+++ b/app/modules/drinks/drinks.server.ts
@@ -1,6 +1,5 @@
 import { createId } from "@paralleldrive/cuid2";
 import { desc, eq } from "drizzle-orm";
-import { FieldDomainError } from "#/app/core/errors";
 import type { getDb } from "#/app/db/client.server";
 import { drinks, type Drink } from "#/app/db/schema";
 import { markdownToHtml } from "./drinks-markdown.server";
@@ -298,7 +297,14 @@ async function createAdminDrink(
     throw new Error("Image buffer is required when creating a drink");
   }
 
-  await ensureSlugAvailable(db, draft.slug);
+  const slugAvailability = await checkSlugAvailability(db, draft.slug);
+  if (!slugAvailability.available) {
+    return {
+      kind: "fieldError" as const,
+      fieldErrors: { slug: ["Slug already exists"] },
+      formErrors: [],
+    };
+  }
 
   const uploadedImage = await writeEffects.uploadImage(imageBuffer, `${draft.slug}.jpg`);
 
@@ -315,21 +321,10 @@ async function createAdminDrink(
   });
 
   return {
+    kind: "success" as const,
     drinkSlug: createdDrink.slug,
     notices: [],
   };
-}
-
-async function ensureSlugAvailable(
-  db: ReturnType<typeof getDb>,
-  slug: string,
-  currentDrinkId?: string,
-): Promise<void> {
-  const slugAvailability = await checkSlugAvailability(db, slug, currentDrinkId);
-
-  if (!slugAvailability.available) {
-    throw new FieldDomainError("slug", "Slug already exists");
-  }
 }
 
 async function checkSlugAvailability(

--- a/app/modules/drinks/drinks.test.ts
+++ b/app/modules/drinks/drinks.test.ts
@@ -326,6 +326,7 @@ describe("createAdminDrinksWriteService", () => {
     });
 
     expect(result).toEqual({
+      kind: "success",
       drinkSlug: "test-cocktail",
       notices: [],
     });
@@ -382,6 +383,7 @@ describe("createAdminDrinksWriteService", () => {
     });
 
     expect(result).toEqual({
+      kind: "success",
       drinkSlug: "admin-write-cocktail",
       notices: [],
     });
@@ -546,7 +548,11 @@ describe("createAdminDrinksWriteService", () => {
         },
         imageBuffer: Buffer.from("fake-image"),
       }),
-    ).rejects.toMatchObject({ field: "slug", message: "Slug already exists" });
+    ).resolves.toEqual({
+      kind: "fieldError",
+      fieldErrors: { slug: ["Slug already exists"] },
+      formErrors: [],
+    });
   });
 
   test("updates an existing drink without replacing its image", async () => {

--- a/app/modules/drinks/drinks.ts
+++ b/app/modules/drinks/drinks.ts
@@ -119,8 +119,10 @@ export type DeleteAdminDrinkSuccessResult = {
 
 export type DeleteAdminDrinkResult = DeleteAdminDrinkSuccessResult | AdminDrinkWriteNotFoundResult;
 
+export type CreateAdminDrinkResult = AdminDrinkWriteSuccessResult | AdminDrinkWriteFieldErrorResult;
+
 export interface AdminDrinksWriteService {
-  create(command: CreateAdminDrinkCommand): Promise<SaveDrinkResult>;
+  create(command: CreateAdminDrinkCommand): Promise<CreateAdminDrinkResult>;
   update(command: UpdateAdminDrinkCommand): Promise<UpdateAdminDrinkResult>;
   delete(command: DeleteAdminDrinkCommand): Promise<DeleteAdminDrinkResult>;
 }

--- a/app/modules/drinks/drinks.ts
+++ b/app/modules/drinks/drinks.ts
@@ -54,7 +54,7 @@ export type SaveDrinkNotice = {
   message: string;
 };
 
-export type SaveDrinkResult = {
+type SaveDrinkResult = {
   drinkSlug: string;
   notices: SaveDrinkNotice[];
 };

--- a/app/routes/admin.drinks.$slug.delete.tsx
+++ b/app/routes/admin.drinks.$slug.delete.tsx
@@ -1,9 +1,9 @@
-import { redirect, href } from "react-router";
-import { intent, routeAction } from "#/app/core/route-action.server";
+import { href, redirect } from "react-router";
 import { getDb } from "#/app/db/client.server";
 import { purgeDrinkCache } from "#/app/integrations/fastly.server";
 import { deleteImage, uploadImage } from "#/app/integrations/imagekit.server";
 import { createAdminDrinksWriteService } from "#/app/modules/drinks/drinks.server";
+import { deleteAdminDrinkActionAdapter } from "#/app/web/admin-drink-write-route-adapter.server";
 import type { Route } from "./+types/admin.drinks.$slug.delete";
 
 export async function loader() {
@@ -16,20 +16,9 @@ export async function action({ request, params }: Route.ActionArgs) {
     writeEffects: { uploadImage, deleteImage, purgeDrinkCache },
   });
 
-  return routeAction(
+  return deleteAdminDrinkActionAdapter({
     request,
-    intent({
-      operation: async () => {
-        const result = await adminDrinksWriteService.delete({ slug: params.slug });
-
-        if (result.kind === "notFound") {
-          throw new Response("Drink not found", { status: 404 });
-        }
-
-        return result;
-      },
-      redirectTo: href("/admin/drinks"),
-      toast: { successMessage: "Drink deleted!" },
-    }),
-  );
+    slug: params.slug,
+    adminDrinksWriteService,
+  });
 }

--- a/app/routes/admin.drinks.$slug.edit.tsx
+++ b/app/routes/admin.drinks.$slug.edit.tsx
@@ -1,18 +1,15 @@
-import { data, href } from "react-router";
-import { DomainError, FieldDomainError } from "#/app/core/errors";
-import { intent, routeAction } from "#/app/core/route-action.server";
+import { href } from "react-router";
 import { getFormErrors } from "#/app/core/utils";
 import { getDb } from "#/app/db/client.server";
 import { purgeDrinkCache } from "#/app/integrations/fastly.server";
 import { deleteImage, uploadImage } from "#/app/integrations/imagekit.server";
-import { drinkDraftSchema, SaveDrinkNoticeCodes } from "#/app/modules/drinks/drinks";
 import {
   createAdminDrinksWriteService,
   createDrinksService,
   DrinkEditorNotFoundError,
 } from "#/app/modules/drinks/drinks.server";
 import { DrinkForm } from "#/app/ui/admin/drink-form";
-import { parseUpdateDrinkSubmission } from "#/app/web/admin-drink-submission.server";
+import { updateAdminDrinkActionAdapter } from "#/app/web/admin-drink-write-route-adapter.server";
 import type { Route } from "./+types/admin.drinks.$slug.edit";
 
 export async function loader({ params }: Route.LoaderArgs) {
@@ -47,57 +44,14 @@ export default function EditDrinkPage({ loaderData, actionData }: Route.Componen
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const submission = await parseUpdateDrinkSubmission(request);
-
-  if (submission.kind === "invalid") {
-    return data(
-      {
-        fieldErrors: submission.fieldErrors,
-        formErrors: submission.formErrors,
-      },
-      { status: submission.status },
-    );
-  }
-
   const adminDrinksWriteService = createAdminDrinksWriteService({
     db: getDb(),
     writeEffects: { uploadImage, deleteImage, purgeDrinkCache },
   });
 
-  return routeAction(
+  return updateAdminDrinkActionAdapter({
     request,
-    intent({
-      schema: drinkDraftSchema,
-      operation: async (draft) => {
-        const result = await adminDrinksWriteService.update({
-          slug: params.slug,
-          draft,
-          imageBuffer: submission.imageUpload?.buffer,
-        });
-
-        if (result.kind === "notFound") {
-          throw new Response("Drink not found", { status: 404 });
-        }
-
-        if (result.kind === "fieldError") {
-          const [field, messages] = Object.entries(result.fieldErrors)[0] ?? [];
-          throw new FieldDomainError(field ?? "slug", messages?.[0] ?? "Invalid drink");
-        }
-
-        return result;
-      },
-      redirectTo: href("/admin/drinks"),
-      toast: (operationResult) => {
-        if (operationResult instanceof DomainError) {
-          return { kind: "error", message: operationResult.message };
-        }
-        return operationResult.notices.some(
-          (notice) => notice.code === SaveDrinkNoticeCodes.oldImageCleanupFailed,
-        )
-          ? { kind: "warning", message: "Drink updated, but old image cleanup failed" }
-          : { kind: "success", message: "Drink updated!" };
-      },
-    }),
-    { formData: submission.formData },
-  );
+    slug: params.slug,
+    adminDrinksWriteService,
+  });
 }

--- a/app/routes/admin.drinks.new.tsx
+++ b/app/routes/admin.drinks.new.tsx
@@ -1,13 +1,11 @@
-import { data, href } from "react-router";
-import { intent, routeAction } from "#/app/core/route-action.server";
+import { href } from "react-router";
 import { getFormErrors } from "#/app/core/utils";
 import { getDb } from "#/app/db/client.server";
 import { purgeDrinkCache } from "#/app/integrations/fastly.server";
 import { deleteImage, uploadImage } from "#/app/integrations/imagekit.server";
-import { drinkDraftSchema } from "#/app/modules/drinks/drinks";
 import { createAdminDrinksWriteService } from "#/app/modules/drinks/drinks.server";
 import { DrinkForm } from "#/app/ui/admin/drink-form";
-import { parseCreateDrinkSubmission } from "#/app/web/admin-drink-submission.server";
+import { createAdminDrinkActionAdapter } from "#/app/web/admin-drink-write-route-adapter.server";
 import type { Route } from "./+types/admin.drinks.new";
 
 export default function NewDrinkPage({ actionData }: Route.ComponentProps) {
@@ -21,36 +19,10 @@ export default function NewDrinkPage({ actionData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const submission = await parseCreateDrinkSubmission(request);
-
-  if (submission.kind === "invalid") {
-    return data(
-      {
-        fieldErrors: submission.fieldErrors,
-        formErrors: submission.formErrors,
-      },
-      { status: submission.status },
-    );
-  }
-
-  const imageUpload = submission.imageUpload;
   const adminDrinksWriteService = createAdminDrinksWriteService({
     db: getDb(),
     writeEffects: { uploadImage, deleteImage, purgeDrinkCache },
   });
 
-  return routeAction(
-    request,
-    intent({
-      schema: drinkDraftSchema,
-      operation: async (draft) =>
-        adminDrinksWriteService.create({
-          draft,
-          imageBuffer: imageUpload.buffer,
-        }),
-      redirectTo: href("/admin/drinks"),
-      toast: { successMessage: "Drink created!" },
-    }),
-    { formData: submission.formData },
-  );
+  return createAdminDrinkActionAdapter({ request, adminDrinksWriteService });
 }

--- a/app/web/admin-drink-write-route-adapter.server.ts
+++ b/app/web/admin-drink-write-route-adapter.server.ts
@@ -1,13 +1,22 @@
 import { data, href } from "react-router";
 import { DomainError, FieldDomainError } from "#/app/core/errors";
 import { intent, routeAction } from "#/app/core/route-action.server";
-import { drinkDraftSchema, type AdminDrinksWriteService } from "#/app/modules/drinks/drinks";
-import { parseCreateDrinkSubmission } from "./admin-drink-submission.server";
+import {
+  drinkDraftSchema,
+  SaveDrinkNoticeCodes,
+  type AdminDrinksWriteService,
+} from "#/app/modules/drinks/drinks";
+import {
+  parseCreateDrinkSubmission,
+  parseUpdateDrinkSubmission,
+} from "./admin-drink-submission.server";
 
-export async function createAdminDrinkActionAdapter(input: {
+type AdminDrinkWriteActionAdapterInput = {
   request: Request;
   adminDrinksWriteService: AdminDrinksWriteService;
-}) {
+};
+
+export async function createAdminDrinkActionAdapter(input: AdminDrinkWriteActionAdapterInput) {
   const submission = await parseCreateDrinkSubmission(input.request);
 
   if (submission.kind === "invalid") {
@@ -43,6 +52,59 @@ export async function createAdminDrinkActionAdapter(input: {
           return { kind: "error", message: operationResult.message };
         }
         return { kind: "success", message: "Drink created!" };
+      },
+    }),
+    { formData: submission.formData },
+  );
+}
+
+export async function updateAdminDrinkActionAdapter(
+  input: AdminDrinkWriteActionAdapterInput & { slug: string },
+) {
+  const submission = await parseUpdateDrinkSubmission(input.request);
+
+  if (submission.kind === "invalid") {
+    return data(
+      {
+        fieldErrors: submission.fieldErrors,
+        formErrors: submission.formErrors,
+      },
+      { status: submission.status },
+    );
+  }
+
+  return routeAction(
+    input.request,
+    intent({
+      schema: drinkDraftSchema,
+      operation: async (draft) => {
+        const result = await input.adminDrinksWriteService.update({
+          slug: input.slug,
+          draft,
+          imageBuffer: submission.imageUpload?.buffer,
+        });
+
+        if (result.kind === "notFound") {
+          throw new Response("Drink not found", { status: 404 });
+        }
+
+        if (result.kind === "fieldError") {
+          const [field, messages] = Object.entries(result.fieldErrors)[0] ?? [];
+          throw new FieldDomainError(field ?? "slug", messages?.[0] ?? "Invalid drink");
+        }
+
+        return result;
+      },
+      redirectTo: href("/admin/drinks"),
+      toast: (operationResult) => {
+        if (operationResult instanceof DomainError) {
+          return { kind: "error", message: operationResult.message };
+        }
+        return operationResult.notices.some(
+          (notice) => notice.code === SaveDrinkNoticeCodes.oldImageCleanupFailed,
+        )
+          ? { kind: "warning", message: "Drink updated, but old image cleanup failed" }
+          : { kind: "success", message: "Drink updated!" };
       },
     }),
     { formData: submission.formData },

--- a/app/web/admin-drink-write-route-adapter.server.ts
+++ b/app/web/admin-drink-write-route-adapter.server.ts
@@ -58,6 +58,27 @@ export async function createAdminDrinkActionAdapter(input: AdminDrinkWriteAction
   );
 }
 
+export async function deleteAdminDrinkActionAdapter(
+  input: AdminDrinkWriteActionAdapterInput & { slug: string },
+) {
+  return routeAction(
+    input.request,
+    intent({
+      operation: async () => {
+        const result = await input.adminDrinksWriteService.delete({ slug: input.slug });
+
+        if (result.kind === "notFound") {
+          throw new Response("Drink not found", { status: 404 });
+        }
+
+        return result;
+      },
+      redirectTo: href("/admin/drinks"),
+      toast: { successMessage: "Drink deleted!" },
+    }),
+  );
+}
+
 export async function updateAdminDrinkActionAdapter(
   input: AdminDrinkWriteActionAdapterInput & { slug: string },
 ) {

--- a/app/web/admin-drink-write-route-adapter.server.ts
+++ b/app/web/admin-drink-write-route-adapter.server.ts
@@ -1,0 +1,50 @@
+import { data, href } from "react-router";
+import { DomainError, FieldDomainError } from "#/app/core/errors";
+import { intent, routeAction } from "#/app/core/route-action.server";
+import { drinkDraftSchema, type AdminDrinksWriteService } from "#/app/modules/drinks/drinks";
+import { parseCreateDrinkSubmission } from "./admin-drink-submission.server";
+
+export async function createAdminDrinkActionAdapter(input: {
+  request: Request;
+  adminDrinksWriteService: AdminDrinksWriteService;
+}) {
+  const submission = await parseCreateDrinkSubmission(input.request);
+
+  if (submission.kind === "invalid") {
+    return data(
+      {
+        fieldErrors: submission.fieldErrors,
+        formErrors: submission.formErrors,
+      },
+      { status: submission.status },
+    );
+  }
+
+  return routeAction(
+    input.request,
+    intent({
+      schema: drinkDraftSchema,
+      operation: async (draft) => {
+        const result = await input.adminDrinksWriteService.create({
+          draft,
+          imageBuffer: submission.imageUpload.buffer,
+        });
+
+        if (result.kind === "fieldError") {
+          const [field, messages] = Object.entries(result.fieldErrors)[0] ?? [];
+          throw new FieldDomainError(field ?? "slug", messages?.[0] ?? "Invalid drink");
+        }
+
+        return result;
+      },
+      redirectTo: href("/admin/drinks"),
+      toast: (operationResult) => {
+        if (operationResult instanceof DomainError) {
+          return { kind: "error", message: operationResult.message };
+        }
+        return { kind: "success", message: "Drink created!" };
+      },
+    }),
+    { formData: submission.formData },
+  );
+}

--- a/app/web/admin-drink-write-route-adapter.test.ts
+++ b/app/web/admin-drink-write-route-adapter.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test, vi } from "vitest";
+import { getToast } from "#/app/core/toast.server";
+import type { AdminDrinksWriteService } from "#/app/modules/drinks/drinks";
+import { createAdminDrinkActionAdapter } from "./admin-drink-write-route-adapter.server";
+
+function buildCreateRequest(input: { slug?: string; imageFile?: File } = {}) {
+  const formData = new FormData();
+  formData.set("title", "Adapter Cocktail");
+  formData.set("slug", input.slug ?? "adapter-cocktail");
+  formData.set("ingredients", "gin\ntonic");
+  formData.set("calories", "150");
+  formData.set("tags", "gin, refreshing");
+  formData.set("notes", "");
+  formData.set("rank", "0");
+  formData.set("status", "published");
+
+  if (input.imageFile) {
+    formData.set("imageFile", input.imageFile);
+  }
+
+  return new Request("http://test.local/admin/drinks/new", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+function buildService(overrides: Partial<AdminDrinksWriteService> = {}): AdminDrinksWriteService {
+  return {
+    create: vi.fn().mockResolvedValue({
+      kind: "success",
+      drinkSlug: "adapter-cocktail",
+      notices: [],
+    }),
+    update: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("createAdminDrinkActionAdapter", () => {
+  test("returns image field errors before calling the admin write path", async () => {
+    const adminDrinksWriteService = buildService();
+
+    const response = await createAdminDrinkActionAdapter({
+      request: buildCreateRequest(),
+      adminDrinksWriteService,
+    });
+
+    expect(response).toMatchObject({
+      data: {
+        fieldErrors: { imageFile: ["Image is required"] },
+        formErrors: [],
+      },
+      init: { status: 400 },
+    });
+    expect(adminDrinksWriteService.create).not.toHaveBeenCalled();
+  });
+
+  test("creates through the admin write path and redirects with the existing success toast", async () => {
+    const adminDrinksWriteService = buildService();
+
+    let redirectResponse: Response | undefined;
+    try {
+      await createAdminDrinkActionAdapter({
+        request: buildCreateRequest({
+          imageFile: new File(["fake-image"], "drink.png", { type: "image/png" }),
+        }),
+        adminDrinksWriteService,
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      redirectResponse = error;
+    }
+
+    expect(redirectResponse).toMatchObject({ status: 302 });
+    expect(redirectResponse?.headers.get("Location")).toBe("/admin/drinks");
+    expect(adminDrinksWriteService.create).toHaveBeenCalledWith({
+      draft: {
+        title: "Adapter Cocktail",
+        slug: "adapter-cocktail",
+        ingredients: ["gin", "tonic"],
+        calories: 150,
+        tags: ["gin", "refreshing"],
+        notes: null,
+        rank: 0,
+        status: "published",
+      },
+      imageBuffer: Buffer.from("fake-image"),
+    });
+
+    const { toast } = await getToast(
+      new Request("http://test.local/admin", {
+        headers: { Cookie: redirectResponse?.headers.get("Set-Cookie") ?? "" },
+      }),
+    );
+    expect(toast).toEqual({ kind: "success", message: "Drink created!" });
+  });
+
+  test("translates typed duplicate slug outcomes into slug field errors", async () => {
+    const adminDrinksWriteService = buildService({
+      create: vi.fn().mockResolvedValue({
+        kind: "fieldError",
+        fieldErrors: { slug: ["Slug already exists"] },
+        formErrors: [],
+      }),
+    });
+
+    const response = await createAdminDrinkActionAdapter({
+      request: buildCreateRequest({
+        slug: "test-margarita",
+        imageFile: new File(["fake-image"], "drink.png", { type: "image/png" }),
+      }),
+      adminDrinksWriteService,
+    });
+
+    expect(response).toMatchObject({
+      data: {
+        fieldErrors: { slug: ["Slug already exists"] },
+        formErrors: [],
+      },
+      init: { status: 400 },
+    });
+  });
+});

--- a/app/web/admin-drink-write-route-adapter.test.ts
+++ b/app/web/admin-drink-write-route-adapter.test.ts
@@ -3,6 +3,7 @@ import { getToast } from "#/app/core/toast.server";
 import type { AdminDrinksWriteService } from "#/app/modules/drinks/drinks";
 import {
   createAdminDrinkActionAdapter,
+  deleteAdminDrinkActionAdapter,
   updateAdminDrinkActionAdapter,
 } from "./admin-drink-write-route-adapter.server";
 
@@ -35,6 +36,13 @@ function buildUpdateRequest(input: { slug?: string; imageFile?: File } = {}) {
   return new Request("http://test.local/admin/drinks/old-fashioned/edit", {
     method: "POST",
     body: buildDrinkFormData(input),
+  });
+}
+
+function buildDeleteRequest() {
+  return new Request("http://test.local/admin/drinks/old-fashioned/delete", {
+    method: "POST",
+    body: new FormData(),
   });
 }
 
@@ -134,6 +142,51 @@ describe("createAdminDrinkActionAdapter", () => {
       },
       init: { status: 400 },
     });
+  });
+});
+
+describe("deleteAdminDrinkActionAdapter", () => {
+  test("deletes through the admin write path and redirects with the existing success toast", async () => {
+    const adminDrinksWriteService = buildService({
+      delete: vi.fn().mockResolvedValue({ kind: "success" }),
+    });
+
+    let redirectResponse: Response | undefined;
+    try {
+      await deleteAdminDrinkActionAdapter({
+        request: buildDeleteRequest(),
+        slug: "old-fashioned",
+        adminDrinksWriteService,
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      redirectResponse = error;
+    }
+
+    expect(redirectResponse).toMatchObject({ status: 302 });
+    expect(redirectResponse?.headers.get("Location")).toBe("/admin/drinks");
+    expect(adminDrinksWriteService.delete).toHaveBeenCalledWith({ slug: "old-fashioned" });
+
+    const { toast } = await getToast(
+      new Request("http://test.local/admin", {
+        headers: { Cookie: redirectResponse?.headers.get("Set-Cookie") ?? "" },
+      }),
+    );
+    expect(toast).toEqual({ kind: "success", message: "Drink deleted!" });
+  });
+
+  test("translates typed missing delete targets into not-found responses", async () => {
+    const adminDrinksWriteService = buildService({
+      delete: vi.fn().mockResolvedValue({ kind: "notFound", slug: "missing-drink" }),
+    });
+
+    await expect(
+      deleteAdminDrinkActionAdapter({
+        request: buildDeleteRequest(),
+        slug: "missing-drink",
+        adminDrinksWriteService,
+      }),
+    ).rejects.toMatchObject({ status: 404 });
   });
 });
 

--- a/app/web/admin-drink-write-route-adapter.test.ts
+++ b/app/web/admin-drink-write-route-adapter.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test, vi } from "vitest";
 import { getToast } from "#/app/core/toast.server";
 import type { AdminDrinksWriteService } from "#/app/modules/drinks/drinks";
-import { createAdminDrinkActionAdapter } from "./admin-drink-write-route-adapter.server";
+import {
+  createAdminDrinkActionAdapter,
+  updateAdminDrinkActionAdapter,
+} from "./admin-drink-write-route-adapter.server";
 
-function buildCreateRequest(input: { slug?: string; imageFile?: File } = {}) {
+function buildDrinkFormData(input: { slug?: string; imageFile?: File } = {}) {
   const formData = new FormData();
   formData.set("title", "Adapter Cocktail");
   formData.set("slug", input.slug ?? "adapter-cocktail");
@@ -18,9 +21,20 @@ function buildCreateRequest(input: { slug?: string; imageFile?: File } = {}) {
     formData.set("imageFile", input.imageFile);
   }
 
+  return formData;
+}
+
+function buildCreateRequest(input: { slug?: string; imageFile?: File } = {}) {
   return new Request("http://test.local/admin/drinks/new", {
     method: "POST",
-    body: formData,
+    body: buildDrinkFormData(input),
+  });
+}
+
+function buildUpdateRequest(input: { slug?: string; imageFile?: File } = {}) {
+  return new Request("http://test.local/admin/drinks/old-fashioned/edit", {
+    method: "POST",
+    body: buildDrinkFormData(input),
   });
 }
 
@@ -119,6 +133,135 @@ describe("createAdminDrinkActionAdapter", () => {
         formErrors: [],
       },
       init: { status: 400 },
+    });
+  });
+});
+
+describe("updateAdminDrinkActionAdapter", () => {
+  test("updates through the admin write path without an image buffer when keeping the current image", async () => {
+    const adminDrinksWriteService = buildService({
+      update: vi.fn().mockResolvedValue({
+        kind: "success",
+        drinkSlug: "adapter-cocktail",
+        notices: [],
+      }),
+    });
+
+    let redirectResponse: Response | undefined;
+    try {
+      await updateAdminDrinkActionAdapter({
+        request: buildUpdateRequest(),
+        slug: "old-fashioned",
+        adminDrinksWriteService,
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      redirectResponse = error;
+    }
+
+    expect(redirectResponse).toMatchObject({ status: 302 });
+    expect(redirectResponse?.headers.get("Location")).toBe("/admin/drinks");
+    expect(adminDrinksWriteService.update).toHaveBeenCalledWith({
+      slug: "old-fashioned",
+      draft: {
+        title: "Adapter Cocktail",
+        slug: "adapter-cocktail",
+        ingredients: ["gin", "tonic"],
+        calories: 150,
+        tags: ["gin", "refreshing"],
+        notes: null,
+        rank: 0,
+        status: "published",
+      },
+      imageBuffer: undefined,
+    });
+
+    const { toast } = await getToast(
+      new Request("http://test.local/admin", {
+        headers: { Cookie: redirectResponse?.headers.get("Set-Cookie") ?? "" },
+      }),
+    );
+    expect(toast).toEqual({ kind: "success", message: "Drink updated!" });
+  });
+
+  test("translates typed duplicate slug update outcomes into slug field errors", async () => {
+    const adminDrinksWriteService = buildService({
+      update: vi.fn().mockResolvedValue({
+        kind: "fieldError",
+        fieldErrors: { slug: ["Slug already exists"] },
+        formErrors: [],
+      }),
+    });
+
+    const response = await updateAdminDrinkActionAdapter({
+      request: buildUpdateRequest({ slug: "test-margarita" }),
+      slug: "old-fashioned",
+      adminDrinksWriteService,
+    });
+
+    expect(response).toMatchObject({
+      data: {
+        fieldErrors: { slug: ["Slug already exists"] },
+        formErrors: [],
+      },
+      init: { status: 400 },
+    });
+  });
+
+  test("translates typed missing update targets into not-found responses", async () => {
+    const adminDrinksWriteService = buildService({
+      update: vi.fn().mockResolvedValue({ kind: "notFound", slug: "missing-drink" }),
+    });
+
+    await expect(
+      updateAdminDrinkActionAdapter({
+        request: buildUpdateRequest(),
+        slug: "missing-drink",
+        adminDrinksWriteService,
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  test("translates old image cleanup notices into the existing warning toast", async () => {
+    const adminDrinksWriteService = buildService({
+      update: vi.fn().mockResolvedValue({
+        kind: "success",
+        drinkSlug: "adapter-cocktail",
+        notices: [
+          {
+            code: "oldImageCleanupFailed",
+            message: "Old image cleanup failed",
+          },
+        ],
+      }),
+    });
+
+    let redirectResponse: Response | undefined;
+    try {
+      await updateAdminDrinkActionAdapter({
+        request: buildUpdateRequest({
+          imageFile: new File(["replacement-image"], "drink.png", { type: "image/png" }),
+        }),
+        slug: "old-fashioned",
+        adminDrinksWriteService,
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      redirectResponse = error;
+    }
+
+    expect(adminDrinksWriteService.update).toHaveBeenCalledWith(
+      expect.objectContaining({ imageBuffer: Buffer.from("replacement-image") }),
+    );
+
+    const { toast } = await getToast(
+      new Request("http://test.local/admin", {
+        headers: { Cookie: redirectResponse?.headers.get("Set-Cookie") ?? "" },
+      }),
+    );
+    expect(toast).toEqual({
+      kind: "warning",
+      message: "Drink updated, but old image cleanup failed",
     });
   });
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,9 +127,7 @@ effects at the service boundary.
 
 Preferred workflow for new work:
 
-1. `grill-me`
-2. `ubiquitous-language`
-3. `write-a-prd`
-4. `prd-to-issues`
-5. `tdd`
-6. `improve-codebase-architecture`
+1. `domain-model`
+2. `to-prd`
+3. `to-issues`
+4. `tdd`


### PR DESCRIPTION
## Summary
- add an admin drink write route adapter for create, update, and delete flows
- thin the admin drink routes so validation, intent handling, redirects, and toasts live in the adapter
- update drink write module contracts, tests, and architecture/domain docs for the adapter seam

## Validation
- `pnpm lint`
- `pnpm typecheck`

Closes #329
Closes #330
Closes #331
Closes #332