### PR TITLE
refactor: deepen admin drink editor read seam

### DIFF
--- a/app/modules/drinks/drinks.server.ts
+++ b/app/modules/drinks/drinks.server.ts
@@ -1,7 +1,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import { desc, eq } from "drizzle-orm";
 import type { getDb } from "#/app/db/client.server";
-import { drinks, type Drink } from "#/app/db/schema";
+import { drinks } from "#/app/db/schema";
 import { markdownToHtml } from "./drinks-markdown.server";
 import { withPlaceholderImages } from "./drinks-images.server";
 import { purgeSearchCache, searchDrinks } from "./drinks-search.server";
@@ -34,13 +34,6 @@ type DrinksWriteEffects = {
   deleteImage: (fileId: string) => Promise<void>;
   purgeDrinkCache: (affectedPages: AffectedDrinkPages) => Promise<void>;
 };
-
-export class DrinkEditorNotFoundError extends Error {
-  constructor(slug: Drink["slug"]) {
-    super(`Drink not found for slug "${slug}"`);
-    this.name = "DrinkEditorNotFoundError";
-  }
-}
 
 export function createDrinksService(deps: { db: Db }): DrinksService {
   return buildDrinksServiceReadMethods({ db: deps.db });
@@ -174,13 +167,13 @@ function buildDrinksServiceReadMethods(deps: { db: Db }): DrinksService {
         },
       };
     },
-    async getDrinkEditorBySlug(slug) {
+    async findDrinkEditorBySlug(slug) {
       const drink = await deps.db.query.drinks.findFirst({
         where: eq(drinks.slug, slug),
       });
 
       if (!drink) {
-        throw new DrinkEditorNotFoundError(slug);
+        return null;
       }
 
       return {

--- a/app/modules/drinks/drinks.test.ts
+++ b/app/modules/drinks/drinks.test.ts
@@ -7,7 +7,6 @@ import { drinkDraftSchema, SaveDrinkNoticeCodes } from "./drinks";
 import {
   createAdminDrinksWriteService,
   createDrinksService,
-  DrinkEditorNotFoundError,
   purgeSearchCache,
 } from "./drinks.server";
 
@@ -40,6 +39,16 @@ beforeEach(async () => {
 async function setDrinkStatus(slug: string, status: "published" | "unpublished"): Promise<void> {
   const db = getDb();
   await db.update(drinks).set({ status }).where(eq(drinks.slug, slug));
+}
+
+async function getExistingDrinkEditor(slug: string) {
+  const editor = await createDrinksService({ db: getDb() }).findDrinkEditorBySlug(slug);
+
+  if (!editor) {
+    throw new Error(`Expected drink editor for slug "${slug}"`);
+  }
+
+  return editor;
 }
 
 describe("createDrinksService", () => {
@@ -87,6 +96,14 @@ describe("createDrinksService", () => {
         status: "published",
       },
     });
+  });
+
+  test("returns null when an editor drink slug is missing", async () => {
+    const service = createDrinksService({ db: getDb() });
+
+    const editor = await service.findDrinkEditorBySlug("missing-drink");
+
+    expect(editor).toBeNull();
   });
 
   test("returns a drink for viewer when a published drink is requested", async () => {
@@ -336,7 +353,7 @@ describe("createAdminDrinksWriteService", () => {
       tags: ["gin", "refreshing"],
     });
 
-    const editor = await createDrinksService({ db: getDb() }).getDrinkEditorBySlug("test-cocktail");
+    const editor = await getExistingDrinkEditor("test-cocktail");
 
     expect(editor).toEqual({
       mode: "edit",
@@ -388,8 +405,7 @@ describe("createAdminDrinksWriteService", () => {
       notices: [],
     });
 
-    const readService = createDrinksService({ db: getDb() });
-    const editor = await readService.getDrinkEditorBySlug("admin-write-cocktail");
+    const editor = await getExistingDrinkEditor("admin-write-cocktail");
     expect(editor.initialValues.title).toBe("Admin Write Cocktail");
     expect(editor.imageUrl).toBe("https://ik.imagekit.io/test/drinks/admin-write-cocktail.jpg");
   });
@@ -429,9 +445,7 @@ describe("createAdminDrinksWriteService", () => {
       tags: ["tequila", "citrus", "lime"],
     });
 
-    const editor = await createDrinksService({ db: getDb() }).getDrinkEditorBySlug(
-      "admin-updated-margarita",
-    );
+    const editor = await getExistingDrinkEditor("admin-updated-margarita");
     expect(editor.initialValues.title).toBe("Admin Updated Margarita");
   });
 
@@ -501,8 +515,8 @@ describe("createAdminDrinksWriteService", () => {
       tags: ["tequila", "citrus"],
     });
     await expect(
-      createDrinksService({ db: getDb() }).getDrinkEditorBySlug("test-margarita"),
-    ).rejects.toThrowError(DrinkEditorNotFoundError);
+      createDrinksService({ db: getDb() }).findDrinkEditorBySlug("test-margarita"),
+    ).resolves.toBeNull();
   });
 
   test("returns a typed not-found outcome when admin delete cannot find a drink", async () => {
@@ -597,9 +611,7 @@ describe("createAdminDrinksWriteService", () => {
       tags: ["tequila", "citrus", "updated"],
     });
 
-    const editor = await createDrinksService({ db: getDb() }).getDrinkEditorBySlug(
-      "test-margarita",
-    );
+    const editor = await getExistingDrinkEditor("test-margarita");
 
     expect(editor).toEqual({
       mode: "edit",
@@ -680,9 +692,7 @@ describe("createAdminDrinksWriteService", () => {
       notices: [{ code: SaveDrinkNoticeCodes.oldImageCleanupFailed, message: "cleanup failed" }],
     });
 
-    const editor = await createDrinksService({ db: getDb() }).getDrinkEditorBySlug(
-      "test-margarita",
-    );
+    const editor = await getExistingDrinkEditor("test-margarita");
     expect(editor.initialValues.title).toBe("Test Margarita");
   });
 
@@ -699,8 +709,8 @@ describe("createAdminDrinksWriteService", () => {
     await service.delete({ slug: "test-margarita" });
 
     await expect(
-      createDrinksService({ db: getDb() }).getDrinkEditorBySlug("test-margarita"),
-    ).rejects.toThrowError(DrinkEditorNotFoundError);
+      createDrinksService({ db: getDb() }).findDrinkEditorBySlug("test-margarita"),
+    ).resolves.toBeNull();
     expect(deleteImage).toHaveBeenCalledWith("seed-fileId-1");
     expect(purgeDrinkCache).toHaveBeenCalledWith({
       slugs: ["test-margarita"],

--- a/app/modules/drinks/drinks.ts
+++ b/app/modules/drinks/drinks.ts
@@ -140,5 +140,5 @@ export interface DrinksService {
   getAllTags(): Promise<DrinkTagView[]>;
   searchPublishedDrinks(input: { query: string }): Promise<DrinkView[]>;
   getNewDrinkEditor(): Promise<DrinkEditor>;
-  getDrinkEditorBySlug(slug: string): Promise<DrinkEditor>;
+  findDrinkEditorBySlug(slug: string): Promise<DrinkEditor | null>;
 }

--- a/app/routes/admin.drinks.$slug.edit.tsx
+++ b/app/routes/admin.drinks.$slug.edit.tsx
@@ -1,4 +1,5 @@
 import { href } from "react-router";
+import { invariantResponse } from "@epic-web/invariant";
 import { getFormErrors } from "#/app/core/utils";
 import { getDb } from "#/app/db/client.server";
 import { purgeDrinkCache } from "#/app/integrations/fastly.server";
@@ -6,7 +7,6 @@ import { deleteImage, uploadImage } from "#/app/integrations/imagekit.server";
 import {
   createAdminDrinksWriteService,
   createDrinksService,
-  DrinkEditorNotFoundError,
 } from "#/app/modules/drinks/drinks.server";
 import { DrinkForm } from "#/app/ui/admin/drink-form";
 import { updateAdminDrinkActionAdapter } from "#/app/web/admin-drink-write/route-adapter.server";
@@ -14,17 +14,11 @@ import type { Route } from "./+types/admin.drinks.$slug.edit";
 
 export async function loader({ params }: Route.LoaderArgs) {
   const drinksService = createDrinksService({ db: getDb() });
+  const editor = await drinksService.findDrinkEditorBySlug(params.slug);
 
-  try {
-    const editor = await drinksService.getDrinkEditorBySlug(params.slug);
-    return { editor, slug: params.slug };
-  } catch (error) {
-    if (error instanceof DrinkEditorNotFoundError) {
-      throw new Response("Drink not found", { status: 404 });
-    }
+  invariantResponse(editor, "Drink not found", { status: 404 });
 
-    throw error;
-  }
+  return { editor, slug: params.slug };
 }
 
 export default function EditDrinkPage({ loaderData, actionData }: Route.ComponentProps) {


### PR DESCRIPTION
## Summary
- rename the admin editor read from `getDrinkEditorBySlug` to `findDrinkEditorBySlug`
- return `null` for missing editor drinks instead of throwing `DrinkEditorNotFoundError`
- keep the route responsible for translating missing editor reads to HTTP 404

## Why / benefits
- improves locality: expected missing-read behavior now lives in the Drinks module interface instead of a route-specific catch block
- improves leverage: callers can use the editor read seam without knowing a module-specific exception type
- keeps the seam simple: no read web adapter yet because this has only two outcomes and no richer response policy
- aligns with existing read interfaces like `getDrinkBySlug` and `getDrinksByTagSlug`, which return `null` for expected misses

## Validation
- `pnpm test app/modules/drinks/drinks.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`