### PR TITLE
chore: enable lockfile maintenance age gate

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "."
+
+minimumReleaseAge: 10080

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
   "major": {
     "automerge": false
   },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am every day"]
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -19,7 +23,8 @@
   "packageRules": [
     {
       "matchDatasources": ["npm"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "internalChecksFilter": "strict"
     },
     {
       "matchPackageNames": ["eslint"],


### PR DESCRIPTION
## Summary
- enable daily Renovate lock file maintenance
- make Renovate npm minimum release age checks strict
- add pnpm 7-day minimum release age for lockfile refreshes

## Validation
- pnpm format
- pnpm lint
- pnpm typecheck