### PR TITLE
chore(deps): update pnpm to v11.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NODE_ENV="production"
 WORKDIR /app
 
 # install pnpm
-RUN npm install -g pnpm@11.0.8
+RUN npm install -g pnpm@11.1.2
 
 # Install all node_modules, including dev dependencies
 FROM base AS dev-deps

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.0.8",
+  "packageManager": "pnpm@11.1.2",
   "pnpm": {
     "onlyBuiltDependencies": [
       "better-sqlite3"


### PR DESCRIPTION
Fixes `ERR_PNPM_OUTDATED_LOCKFILE` on every Renovate PR since #338 (visible on #339, #340, #341).

## Root-cause summary

| Layer | Behavior |
|---|---|
| npm registry | Abbreviated metadata response (`application/vnd.npm.install-v1+json`) intermittently omits the per-version `time` field for some packages (confirmed via `curl` against `playwright`). |
| pnpm v11.0.4 changelog | `minimumReleaseAgeStrict` now defaults to `true` whenever the user explicitly sets `minimumReleaseAge`. |
| pnpm v11.0.4–11.1.1 | Under that strict mode, missing-time → hard `ERR_PNPM_MISSING_TIME` instead of warn-and-skip. |
| Renovate artifact step | Runs `pnpm install` to update `pnpm-lock.yaml` after bumping a dep in `package.json`. Hits the error, aborts, commits only `package.json`. |
| CI on the resulting PR | `pnpm install` (frozen) sees mismatched `package.json` vs `pnpm-lock.yaml` → `ERR_PNPM_OUTDATED_LOCKFILE`. |
| pnpm v11.1.2 | Falls through to `fullMetadata: true` fetch when abbreviated metadata lacks `time` ([pnpm/pnpm#11619](https://github.com/pnpm/pnpm/issues/11619)). |

Timeline that made it appear:

- **2026-05-02** — `minimumReleaseAge: 10080` added to `pnpm-workspace.yaml` while still on pnpm v10 (strict default `false`, so missing-time was a `WARN`).
- **2026-05-13** — Renovate auto-merged pnpm v11 (#338, then 11.0.8). Implicit strict mode flipped `WARN` → `ERROR`.
- **2026-05-14** — every open Renovate PR fails the artifact step, then CI.

## What this PR does

Bumps pnpm `11.0.8` → `11.1.2` in both places it's pinned:

- `package.json` `packageManager`
- `Dockerfile` global install

## Verification

After merge, tick the rebase checkbox on #339 / #340 / #341. The `renovate/artifacts` status should go green and each PR should contain a `pnpm-lock.yaml` update alongside its `package.json` bump.
