### PR TITLE
fix: disable pnpm's verifyDepsBeforeRun in Docker runtime layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN pnpm run build
 # Finally, build the runtime image with minimal footprint
 FROM base AS runtime
 
+# Disable verifyDepsBeforeRun as the lockfile is immutable and dependencies are pre-verified
+ENV PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN="false"
+
 ENV PORT="8080"
 
 COPY --from=prod-deps /app/node_modules /app/node_modules


### PR DESCRIPTION
This pull request makes a small change to the `Dockerfile` to improve container startup performance and reliability. The change disables the `pnpm` dependency verification check at runtime, since dependencies are already verified and the lockfile is immutable.

* Docker build/runtime optimization:
  * Disabled `pnpm`'s `verifyDepsBeforeRun` check by setting the `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN` environment variable to `false` in the runtime image, as dependencies are pre-verified and the lockfile is immutable.