### PR TITLE
chore: enable v8 future flags

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -4,6 +4,10 @@ export default {
   future: {
     unstable_optimizeDeps: true,
     v8_middleware: true,
+    v8_passThroughRequests: true,
+    v8_splitRouteModules: true,
+    v8_trailingSlashAwareDataRequests: true,
+    v8_viteEnvironmentApi: true,
   },
   ssr: true,
 } satisfies Config;


### PR DESCRIPTION
## Summary

Enables React Router v8 future flags already supported by our current v7 version.

## Enabled flags

- `v8_passThroughRequests`: loaders/actions/middleware see the original incoming `request.url` instead of React Router-normalized URLs.
- `v8_splitRouteModules`: splits route exports into smaller client chunks so unrelated routes ship less JS.
- `v8_trailingSlashAwareDataRequests`: makes data requests match document request path behavior for trailing slashes; no app action needed.
- `v8_viteEnvironmentApi`: uses Vite’s newer Environment API for client/server builds; app behavior should not change.

`v8_middleware` was already enabled.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:rr`
