### PR TITLE
fix: restore Fly deployment after better-sqlite3 v13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base node image
-FROM node:24-bullseye-slim AS base
+FROM node:24-bookworm-slim AS base
 
 # set for base and all layers that inherit from it
 ENV NODE_ENV="production"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - "."
 
 allowBuilds:
-  better-sqlite3: true
+  better-sqlite3: false
   esbuild: false
   msw: false
   unrs-resolver: false


### PR DESCRIPTION
## Summary

Restores Fly.io deployments broken by #359.

- use Bookworm's glibc for the native binary bundled with better-sqlite3 v13
- skip its redundant implicit `node-gyp` rebuild

## Root cause

The v13 upgrade triggered `node-gyp` in the toolchain-free Bullseye image. Its bundled Linux binary also requires a newer glibc than Bullseye provides.

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- clean production dependency image build
- clean full runtime image build
- in-container SQLite query
